### PR TITLE
Fix clearing WYSIWYG editor after second reply

### DIFF
--- a/resources/assets/js/components/NewReply.vue
+++ b/resources/assets/js/components/NewReply.vue
@@ -2,7 +2,7 @@
     <div>
         <div v-if="signedIn">
             <div class="form-group">
-                <wysiwyg name="body" v-model="body" placeholder="Have something to say?" :shouldClear="completed"></wysiwyg>
+                <wysiwyg name="body" v-model="body" placeholder="Have something to say?" v-on:input="typed" :shouldClear="completed"></wysiwyg>
             </div>
 
             <button type="submit"
@@ -57,6 +57,9 @@
 
                         this.$emit('created', data);
                     });
+            },
+            typed() {
+                this.completed = false;
             }
         }
     }


### PR DESCRIPTION
Commit adds event handling for `input` event from `Wysiwyg` component in `NewReply` component to reset `completed` flag. Without this, when user is replied to this same thread twice (and more) without refreshing browser, editor hasn't cleared, because flag `completed` was set to `true` after first time and watcher hadn't see change.

Event handler just resets flag `completed` and after each reply, editor's content will be cleared.

PS. app.js is added, because it would be inconsistent otherwise. However it is not a good practice to keep assets in repository => generated unnecessary merge conflicts.