### PR TITLE
Add Hash::setRounds(4) to CreatesApplication trait to speed up tests

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
@@ -16,6 +17,8 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+
+        Hash::setRounds(4);
 
         return $app;
     }


### PR DESCRIPTION
I understand the tests aren't all passing at this time, but this is now standard practice for speeding up test execution.