### PR TITLE
Warn when a test doesn't assert anything

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
          bootstrap="bootstrap/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"


### PR DESCRIPTION
This PR updates the PHPUnit configuration file to warn when a test didn't perform assertions.

:octocat: 