### PR TITLE
Use RefreshDatabase trait instead of DatabaseMigrations

### DIFF
--- a/tests/Feature/AddAvatarTest.php
+++ b/tests/Feature/AddAvatarTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class AddAvatarTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     public function only_members_can_add_avatars()

--- a/tests/Feature/BestReplyTest.php
+++ b/tests/Feature/BestReplyTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class BestReplyTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function a_thread_creator_may_mark_any_reply_as_the_best_reply()

--- a/tests/Feature/CreateThreadsTest.php
+++ b/tests/Feature/CreateThreadsTest.php
@@ -4,13 +4,13 @@ namespace Tests\Feature;
 
 use App\Activity;
 use App\Rules\Recaptcha;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
 
 class CreateThreadsTest extends TestCase
 {
-    use DatabaseMigrations, MockeryPHPUnitIntegration;
+    use RefreshDatabase, MockeryPHPUnitIntegration;
 
     public function setUp()
     {

--- a/tests/Feature/FavoritesTest.php
+++ b/tests/Feature/FavoritesTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class FavoritesTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function guests_can_not_favorite_anything()

--- a/tests/Feature/LockThreadsTest.php
+++ b/tests/Feature/LockThreadsTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class LockThreadsTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function non_administrators_may_not_lock_threads()

--- a/tests/Feature/MentionUsersTest.php
+++ b/tests/Feature/MentionUsersTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class MentionUsersTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function mentioned_users_in_a_reply_are_notified()

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\DatabaseNotification;
 use Tests\TestCase;
 
 class NotificationsTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     public function setUp()
     {

--- a/tests/Feature/ParticipateInThreadsTest.php
+++ b/tests/Feature/ParticipateInThreadsTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ParticipateInThreadsTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function unauthenticated_users_may_not_add_replies()

--- a/tests/Feature/ProfilesTest.php
+++ b/tests/Feature/ProfilesTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class ProfilesTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function a_user_has_a_profile()

--- a/tests/Feature/ReadThreadsTest.php
+++ b/tests/Feature/ReadThreadsTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ReadThreadsTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     protected $thread;
 

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -4,13 +4,13 @@ namespace Tests\Feature;
 
 use App\Mail\PleaseConfirmYourEmail;
 use App\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function a_confirmation_email_is_sent_upon_registration()

--- a/tests/Feature/SubscribeToThreadsTest.php
+++ b/tests/Feature/SubscribeToThreadsTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class SubscribeToThreadsTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     public function a_user_can_subscribe_to_threads()

--- a/tests/Feature/TrendingThreadsTest.php
+++ b/tests/Feature/TrendingThreadsTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Feature;
 
 use App\Trending;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class TrendingThreadsTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     protected function setUp()
     {

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -4,12 +4,12 @@ namespace Tests\Feature;
 
 use App\Activity;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ActivityTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     public function it_records_activity_when_a_thread_is_created()

--- a/tests/Unit/ChannelTest.php
+++ b/tests/Unit/ChannelTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class ChannelTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
     
     /** @test */
     public function a_channel_consists_of_threads()

--- a/tests/Unit/ReplyTest.php
+++ b/tests/Unit/ReplyTest.php
@@ -4,12 +4,12 @@ namespace Tests\Unit;
 
 use App\Reply;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ReplyTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /** @test */
     function it_has_an_owner()

--- a/tests/Unit/ThreadTest.php
+++ b/tests/Unit/ThreadTest.php
@@ -3,13 +3,13 @@
 namespace Tests\Unit;
 
 use App\Notifications\ThreadWasUpdated;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class ThreadTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     protected $thread;
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class UserTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
     
     /** @test */
     public function a_user_can_fetch_their_most_recent_reply()


### PR DESCRIPTION
Should improve performance when running test suites.