### PR TITLE
Make it clear that the reply owner gets the reputation award reduction

### DIFF
--- a/tests/Feature/ReputationTest.php
+++ b/tests/Feature/ReputationTest.php
@@ -125,9 +125,9 @@ class ReputationTest extends TestCase
     /** @test */
     public function a_user_loses_points_when_their_favorited_reply_is_unfavorited()
     {
+        $reply = create('App\Reply', ['user_id' => create('App\User')]);
+        
         $this->signIn();
-
-        $reply = create('App\Reply', ['user_id' => auth()->id()]);
 
         $this->post("/replies/{$reply->id}/favorites");
 
@@ -138,5 +138,6 @@ class ReputationTest extends TestCase
 
         $total = Reputation::REPLY_POSTED + Reputation::REPLY_FAVORITED - Reputation::REPLY_FAVORITED;
         $this->assertEquals($total, $reply->owner->fresh()->reputation);
+        $this->assertEquals(0, auth()->user()->reputation);
     }
 }


### PR DESCRIPTION
I believe that the story being told by this test should be more explicit - there are two distinct users, the reply owner and the authenticated user who favorites and unfavorites the reply.