### PR TITLE
fix broken test in ThreadTest

### DIFF
--- a/tests/Unit/ThreadTest.php
+++ b/tests/Unit/ThreadTest.php
@@ -26,7 +26,8 @@ class ThreadTest extends TestCase
         $thread = create('App\Thread');
 
         $this->assertEquals(
-            "/threads/{$thread->channel->slug}/{$thread->slug}", $thread->path()
+            "/threads/{$thread->channel->slug}/{$thread->slug}",
+            $thread->path()
         );
     }
 
@@ -40,7 +41,8 @@ class ThreadTest extends TestCase
     function a_thread_has_replies()
     {
         $this->assertInstanceOf(
-            'Illuminate\Database\Eloquent\Collection', $this->thread->replies
+            'Illuminate\Database\Eloquent\Collection',
+            $this->thread->replies
         );
     }
 
@@ -78,7 +80,7 @@ class ThreadTest extends TestCase
             ->subscribe()
             ->addReply([
                 'body' => 'Foobar',
-                'user_id' => 999
+                'user_id' => create('App\User')->id
             ]);
 
         Notification::assertSentTo(auth()->user(), ThreadWasUpdated::class);


### PR DESCRIPTION
a_thread_notifies_all_registered_subscribers_when_a_reply_is_added was broken after adding reputation logic in Reply.php's boot method.

Because user_id was hardcoded to 999 in the unit test, it attempted to add reputation points to a user that didn't exists. I changed it so that a new user is created when the reply is created in the test.

Also, VS Code really likes to reformat code that doesn't need it sometimes ☺️