### PR TITLE
Adding name to all routes and refactoring some tests to use them

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -15,38 +15,38 @@ Route::redirect('/', 'threads');
 
 Auth::routes();
 
-Route::get('/home', 'HomeController@index');
+Route::get('/home', 'HomeController@index')->name('home');
 
 Route::get('threads', 'ThreadsController@index')->name('threads');
-Route::get('threads/create', 'ThreadsController@create')->middleware('must-be-confirmed');
-Route::get('threads/search', 'SearchController@show');
-Route::get('threads/{channel}/{thread}', 'ThreadsController@show');
-Route::patch('threads/{channel}/{thread}', 'ThreadsController@update');
-Route::delete('threads/{channel}/{thread}', 'ThreadsController@destroy');
-Route::post('threads', 'ThreadsController@store')->middleware('must-be-confirmed');
-Route::get('threads/{channel}', 'ThreadsController@index');
+Route::get('threads/create', 'ThreadsController@create')->middleware('must-be-confirmed')->name('threads.create');
+Route::get('threads/search', 'SearchController@show')->name('search.show');
+Route::get('threads/{channel}/{thread}', 'ThreadsController@show')->name('threads.show');
+Route::patch('threads/{channel}/{thread}', 'ThreadsController@update')->name('threads.update');
+Route::delete('threads/{channel}/{thread}', 'ThreadsController@destroy')->name('threads.destroy');
+Route::post('threads', 'ThreadsController@store')->middleware('must-be-confirmed')->name('threads.store');
+Route::get('threads/{channel}', 'ThreadsController@index')->name('channels');
 
 Route::post('locked-threads/{thread}', 'LockedThreadsController@store')->name('locked-threads.store')->middleware('admin');
 Route::delete('locked-threads/{thread}', 'LockedThreadsController@destroy')->name('locked-threads.destroy')->middleware('admin');
 
-Route::get('/threads/{channel}/{thread}/replies', 'RepliesController@index');
-Route::post('/threads/{channel}/{thread}/replies', 'RepliesController@store')->middleware('must-be-confirmed');
-Route::patch('/replies/{reply}', 'RepliesController@update');
+Route::get('/threads/{channel}/{thread}/replies', 'RepliesController@index')->name('replies');
+Route::post('/threads/{channel}/{thread}/replies', 'RepliesController@store')->middleware('must-be-confirmed')->name('replies.store');
+Route::patch('/replies/{reply}', 'RepliesController@update')->name('replies.update');
 Route::delete('/replies/{reply}', 'RepliesController@destroy')->name('replies.destroy');
 
 Route::post('/replies/{reply}/best', 'BestRepliesController@store')->name('best-replies.store');
 
-Route::post('/threads/{channel}/{thread}/subscriptions', 'ThreadSubscriptionsController@store')->middleware('auth');
-Route::delete('/threads/{channel}/{thread}/subscriptions', 'ThreadSubscriptionsController@destroy')->middleware('auth');
+Route::post('/threads/{channel}/{thread}/subscriptions', 'ThreadSubscriptionsController@store')->middleware('auth')->name('threads.store');
+Route::delete('/threads/{channel}/{thread}/subscriptions', 'ThreadSubscriptionsController@destroy')->middleware('auth')->name('threads.destroy');
 
-Route::post('/replies/{reply}/favorites', 'FavoritesController@store');
-Route::delete('/replies/{reply}/favorites', 'FavoritesController@destroy');
+Route::post('/replies/{reply}/favorites', 'FavoritesController@store')->name('replies.favorite');
+Route::delete('/replies/{reply}/favorites', 'FavoritesController@destroy')->name('replies.unfavorite');
 
 Route::get('/profiles/{user}', 'ProfilesController@show')->name('profile');
-Route::get('/profiles/{user}/notifications', 'UserNotificationsController@index');
-Route::delete('/profiles/{user}/notifications/{notification}', 'UserNotificationsController@destroy');
+Route::get('/profiles/{user}/notifications', 'UserNotificationsController@index')->name('user-notifications');
+Route::delete('/profiles/{user}/notifications/{notification}', 'UserNotificationsController@destroy')->name('user-notification.destroy');
 
 Route::get('/register/confirm', 'Auth\RegisterConfirmationController@index')->name('register.confirm');
 
-Route::get('api/users', 'Api\UsersController@index');
+Route::get('api/users', 'Api\UsersController@index')->name('api.users');
 Route::post('api/users/{user}/avatar', 'Api\UserAvatarController@store')->middleware('auth')->name('avatar');

--- a/tests/Feature/AddAvatarTest.php
+++ b/tests/Feature/AddAvatarTest.php
@@ -25,7 +25,7 @@ class AddAvatarTest extends TestCase
     {
         $this->withExceptionHandling()->signIn();
 
-        $this->json('POST', 'api/users/' . auth()->id() . '/avatar', [
+        $this->json('POST', route('avatar', auth()->id()), [
             'avatar' => 'not-an-image'
         ])->assertStatus(422);
     }
@@ -37,7 +37,7 @@ class AddAvatarTest extends TestCase
 
         Storage::fake('public');
 
-        $this->json('POST', 'api/users/' . auth()->id() . '/avatar', [
+        $this->json('POST', route('avatar', auth()->id()), [
             'avatar' => $file = UploadedFile::fake()->image('avatar.jpg')
         ]);
 

--- a/tests/Feature/FavoritesTest.php
+++ b/tests/Feature/FavoritesTest.php
@@ -24,7 +24,7 @@ class FavoritesTest extends TestCase
 
         $reply = create('App\Reply');
 
-        $this->post('replies/' . $reply->id . '/favorites');
+        $this->post(route('replies.favorite', $reply->id));
 
         $this->assertCount(1, $reply->favorites);
     }
@@ -38,7 +38,7 @@ class FavoritesTest extends TestCase
 
         $reply->favorite();
 
-        $this->delete('replies/' . $reply->id . '/favorites');
+        $this->delete(route('replies.unfavorite', $reply->id));
 
         $this->assertCount(0, $reply->favorites);
     }
@@ -51,8 +51,8 @@ class FavoritesTest extends TestCase
         $reply = create('App\Reply');
 
         try {
-            $this->post('replies/' . $reply->id . '/favorites');
-            $this->post('replies/' . $reply->id . '/favorites');
+            $this->post(route('replies.favorite', $reply->id));
+            $this->post(route('replies.favorite', $reply->id));
         } catch (\Exception $e) {
             $this->fail('Did not expect to insert the same record set twice.');
         }

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -46,7 +46,7 @@ class NotificationsTest extends TestCase
 
         $this->assertCount(
             1,
-            $this->getJson("/profiles/" . auth()->user()->name . "/notifications")->json()
+            $this->getJson(route('user-notifications', auth()->user()->name))->json()
         );
     }
 
@@ -58,7 +58,7 @@ class NotificationsTest extends TestCase
         tap(auth()->user(), function ($user) {
             $this->assertCount(1, $user->unreadNotifications);
 
-            $this->delete("/profiles/{$user->name}/notifications/" . $user->unreadNotifications->first()->id);
+            $this->delete(route('user-notification.destroy', [$user->name, $user->unreadNotifications->first()->id]));
 
             $this->assertCount(0, $user->fresh()->unreadNotifications);
         });

--- a/tests/Feature/ParticipateInThreadsTest.php
+++ b/tests/Feature/ParticipateInThreadsTest.php
@@ -78,11 +78,11 @@ class ParticipateInThreadsTest extends TestCase
 
         $reply = create('App\Reply');
 
-        $this->patch("/replies/{$reply->id}")
+        $this->patch(route('replies.update', $reply->id))
             ->assertRedirect('login');
 
         $this->signIn()
-            ->patch("/replies/{$reply->id}")
+            ->patch(route('replies.update', $reply->id))
             ->assertStatus(403);
     }
 
@@ -94,7 +94,7 @@ class ParticipateInThreadsTest extends TestCase
         $reply = create('App\Reply', ['user_id' => auth()->id()]);
 
         $updatedReply = 'You been changed, fool.';
-        $this->patch("/replies/{$reply->id}", ['body' => $updatedReply]);
+        $this->patch(route('replies.update', $reply->id), ['body' => $updatedReply]);
 
         $this->assertDatabaseHas('replies', ['id' => $reply->id, 'body' => $updatedReply]);
     }

--- a/tests/Feature/ProfilesTest.php
+++ b/tests/Feature/ProfilesTest.php
@@ -25,9 +25,8 @@ class ProfilesTest extends TestCase
 
         $thread = create('App\Thread', ['user_id' => auth()->id()]);
 
-        $this->get("/profiles/" . auth()->user()->name)
+        $this->get(route('profile', auth()->user()->name))
             ->assertSee($thread->title)
             ->assertSee($thread->body);
-
     }
 }

--- a/tests/Feature/ReadThreadsTest.php
+++ b/tests/Feature/ReadThreadsTest.php
@@ -39,7 +39,7 @@ class ReadThreadsTest extends TestCase
         $threadInChannel = create('App\Thread', ['channel_id' => $channel->id]);
         $threadNotInChannel = create('App\Thread');
 
-        $this->get('/threads/' . $channel->slug)
+        $this->get(route('channels', $channel->slug))
             ->assertSee($threadInChannel->title)
             ->assertDontSee($threadNotInChannel->title);
     }

--- a/tests/Feature/ReputationTest.php
+++ b/tests/Feature/ReputationTest.php
@@ -54,7 +54,7 @@ class ReputationTest extends TestCase
 
         $this->assertEquals(Reputation::REPLY_POSTED, $reply->owner->reputation);
 
-        $this->delete("/replies/{$reply->id}");
+        $this->delete(route('replies.destroy',$reply->id));
 
         $this->assertEquals(0, $reply->owner->fresh()->reputation);
     }
@@ -114,7 +114,7 @@ class ReputationTest extends TestCase
             'body' => 'Some reply'
         ]);
 
-        $this->post("/replies/{$reply->id}/favorites");
+        $this->post(route('replies.favorite', $reply->id));
 
         $total = Reputation::REPLY_POSTED + Reputation::REPLY_FAVORITED;
 
@@ -129,12 +129,12 @@ class ReputationTest extends TestCase
 
         $reply = create('App\Reply', ['user_id' => auth()->id()]);
 
-        $this->post("/replies/{$reply->id}/favorites");
+        $this->post(route('replies.favorite', $reply->id));
 
         $total = Reputation::REPLY_POSTED + Reputation::REPLY_FAVORITED;
         $this->assertEquals($total, $reply->owner->fresh()->reputation);
 
-        $this->delete("/replies/{$reply->id}/favorites");
+        $this->delete(route('replies.unfavorite', $reply->id));
 
         $total = Reputation::REPLY_POSTED + Reputation::REPLY_FAVORITED - Reputation::REPLY_FAVORITED;
         $this->assertEquals($total, $reply->owner->fresh()->reputation);


### PR DESCRIPTION
Nothing special, just added names to all routes.
I haven't touched the tests that used $thread->path() for obvious reasons :)