### PR TITLE
Use Laravel's collection method 

### DIFF
--- a/resources/views/admin/channels/index.blade.php
+++ b/resources/views/admin/channels/index.blade.php
@@ -3,7 +3,7 @@
 @section('administration-content')
 
         <p><a class="btn btn-sm btn-default" href="{{ route('admin.channels.create') }}">New Channel <span class="glyphicon glyphicon-plus"></span></a></p>
-    
+
         <table class="table">
             <thead>
             <tr>
@@ -19,7 +19,7 @@
                     <td>{{$channel->name}}</td>
                     <td>{{$channel->slug}}</td>
                     <td>{{$channel->description}}</td>
-                    <td>{{ count($channel->threads()) }}</td>
+                    <td>{{ $channel->threads()->count() }}</td>
                 </tr>
             @empty
                 <tr>


### PR DESCRIPTION
While its okay to use count(), why don't we use laravel's own collection method's `->count()`.
Also, I noticed that in PHP 7.2 there is a warning saying, 

> count(): Parameter  must be an array or an object that implements Countable 