### PR TITLE
Prettify imports

### DIFF
--- a/app/Events/ThreadReceivedNewReply.php
+++ b/app/Events/ThreadReceivedNewReply.php
@@ -2,8 +2,8 @@
 
 namespace App\Events;
 
-use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class ThreadReceivedNewReply
 {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,8 +4,8 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
 {

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller;
 use App\User;
+use App\Http\Controllers\Controller;
 
 class UsersController extends Controller
 {

--- a/app/Http/Controllers/Auth/RegisterConfirmationController.php
+++ b/app/Http/Controllers/Auth/RegisterConfirmationController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\User;
+use App\Http\Controllers\Controller;
 
 class RegisterConfirmationController extends Controller
 {

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
-use App\Mail\PleaseConfirmYourEmail;
 use App\User;
-use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Http\Request;
+use App\Mail\PleaseConfirmYourEmail;
 use Illuminate\Support\Facades\Mail;
+use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Foundation\Auth\RegistersUsers;
 
 class RegisterController extends Controller
 {

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Activity;
 use App\User;
+use App\Activity;
 
 class ProfilesController extends Controller
 {

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\CreatePostRequest;
 use App\Reply;
 use App\Thread;
+use App\Http\Requests\CreatePostRequest;
 
 class RepliesController extends Controller
 {

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use App\Channel;
-use App\Filters\ThreadFilters;
-use App\Rules\Recaptcha;
 use App\Thread;
+use App\Channel;
 use App\Trending;
+use App\Rules\Recaptcha;
+use App\Filters\ThreadFilters;
 
 class ThreadsController extends Controller
 {

--- a/app/Http/Requests/CreatePostRequest.php
+++ b/app/Http/Requests/CreatePostRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Support\Facades\Gate;
 use App\Exceptions\ThrottleException;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Gate;
 
 class CreatePostRequest extends FormRequest
 {

--- a/app/Listeners/NotifyMentionedUsers.php
+++ b/app/Listeners/NotifyMentionedUsers.php
@@ -2,9 +2,9 @@
 
 namespace App\Listeners;
 
+use App\User;
 use App\Events\ThreadReceivedNewReply;
 use App\Notifications\YouWereMentioned;
-use App\User;
 
 class NotifyMentionedUsers
 {

--- a/app/Mail/PleaseConfirmYourEmail.php
+++ b/app/Mail/PleaseConfirmYourEmail.php
@@ -3,9 +3,9 @@
 namespace App\Mail;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PleaseConfirmYourEmail extends Mailable implements ShouldQueue
 {

--- a/app/Policies/ReplyPolicy.php
+++ b/app/Policies/ReplyPolicy.php
@@ -2,8 +2,8 @@
 
 namespace App\Policies;
 
-use App\Reply;
 use App\User;
+use App\Reply;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class ReplyPolicy

--- a/app/Policies/ThreadPolicy.php
+++ b/app/Policies/ThreadPolicy.php
@@ -2,8 +2,8 @@
 
 namespace App\Policies;
 
-use App\Thread;
 use App\User;
+use App\Thread;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class ThreadPolicy

--- a/app/RecordsActivity.php
+++ b/app/RecordsActivity.php
@@ -2,7 +2,6 @@
 
 namespace App;
 
-
 trait RecordsActivity
 {
     /**

--- a/app/Rules/Recaptcha.php
+++ b/app/Rules/Recaptcha.php
@@ -2,8 +2,8 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
 use Zttp\Zttp;
+use Illuminate\Contracts\Validation\Rule;
 
 class Recaptcha implements Rule
 {

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -2,11 +2,11 @@
 
 namespace App;
 
-use App\Events\ThreadReceivedNewReply;
-use App\Filters\ThreadFilters;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Laravel\Scout\Searchable;
+use App\Filters\ThreadFilters;
+use App\Events\ThreadReceivedNewReply;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class Thread extends Model
 {

--- a/app/User.php
+++ b/app/User.php
@@ -3,8 +3,8 @@
 namespace App;
 
 use Carbon\Carbon;
-use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class User extends Authenticatable
 {

--- a/tests/Console/InstallCommandTest.php
+++ b/tests/Console/InstallCommandTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Console;
 
-use Illuminate\Support\Facades\File;
 use Mockery;
 use Tests\TestCase;
+use Illuminate\Support\Facades\File;
 
 class InstallCommandTest extends TestCase
 {

--- a/tests/Feature/AddAvatarTest.php
+++ b/tests/Feature/AddAvatarTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class AddAvatarTest extends TestCase
 {

--- a/tests/Feature/Admin/AdministratorTest.php
+++ b/tests/Feature/Admin/AdministratorTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Admin;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class AdministratorTest extends TestCase
 {

--- a/tests/Feature/Admin/ChannelAdministrationTest.php
+++ b/tests/Feature/Admin/ChannelAdministrationTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature\Admin;
 
-use App\Channel;
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Symfony\Component\HttpFoundation\Response;
+use App\Channel;
 use Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ChannelAdministrationTest extends TestCase
 {

--- a/tests/Feature/BestReplyTest.php
+++ b/tests/Feature/BestReplyTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class BestReplyTest extends TestCase
 {

--- a/tests/Feature/CreateThreadsTest.php
+++ b/tests/Feature/CreateThreadsTest.php
@@ -3,10 +3,10 @@
 namespace Tests\Feature;
 
 use App\Activity;
+use Tests\TestCase;
 use App\Rules\Recaptcha;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use Tests\TestCase;
 
 class CreateThreadsTest extends TestCase
 {

--- a/tests/Feature/FavoritesTest.php
+++ b/tests/Feature/FavoritesTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class FavoritesTest extends TestCase
 {

--- a/tests/Feature/LockThreadsTest.php
+++ b/tests/Feature/LockThreadsTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class LockThreadsTest extends TestCase
 {

--- a/tests/Feature/MentionUsersTest.php
+++ b/tests/Feature/MentionUsersTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class MentionUsersTest extends TestCase
 {

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Notifications\DatabaseNotification;
 use Tests\TestCase;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class NotificationsTest extends TestCase
 {

--- a/tests/Feature/ParticipateInThreadsTest.php
+++ b/tests/Feature/ParticipateInThreadsTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ParticipateInThreadsTest extends TestCase
 {

--- a/tests/Feature/ProfilesTest.php
+++ b/tests/Feature/ProfilesTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ProfilesTest extends TestCase
 {

--- a/tests/Feature/ReadThreadsTest.php
+++ b/tests/Feature/ReadThreadsTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ReadThreadsTest extends TestCase
 {

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use App\Mail\PleaseConfirmYourEmail;
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
+use App\Mail\PleaseConfirmYourEmail;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class RegistrationTest extends TestCase
 {

--- a/tests/Feature/ReputationTest.php
+++ b/tests/Feature/ReputationTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Reputation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ReputationTest extends TestCase
 {

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use App\Thread;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class SearchTest extends TestCase
 {

--- a/tests/Feature/SubscribeToThreadsTest.php
+++ b/tests/Feature/SubscribeToThreadsTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class SubscribeToThreadsTest extends TestCase
 {

--- a/tests/Feature/TrendingThreadsTest.php
+++ b/tests/Feature/TrendingThreadsTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use App\Trending;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class TrendingThreadsTest extends TestCase
 {

--- a/tests/Feature/UpdateThreadsTest.php
+++ b/tests/Feature/UpdateThreadsTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UpdateThreadsTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use App\Exceptions\Handler;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
-use Illuminate\Support\Facades\DB;
 
 abstract class TestCase extends BaseTestCase
 {

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Activity;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ActivityTest extends TestCase
 {

--- a/tests/Unit/ChannelTest.php
+++ b/tests/Unit/ChannelTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ChannelTest extends TestCase
 {

--- a/tests/Unit/ReplyTest.php
+++ b/tests/Unit/ReplyTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit;
 
 use App\Reply;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ReplyTest extends TestCase
 {

--- a/tests/Unit/SpamTest.php
+++ b/tests/Unit/SpamTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use App\Inspections\Spam;
 use Tests\TestCase;
+use App\Inspections\Spam;
 
 class SpamTest extends TestCase
 {

--- a/tests/Unit/ThreadTest.php
+++ b/tests/Unit/ThreadTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit;
 
-use App\Notifications\ThreadWasUpdated;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
+use App\Notifications\ThreadWasUpdated;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ThreadTest extends TestCase
 {

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UserTest extends TestCase
 {


### PR DESCRIPTION
This PR orders use statements by length in order to 'prettify' them, a scheme that is used throughout Laravel and its generated classes.