### PR TITLE
Simplify Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,12 @@ language: php
 
 php:
   - 7.1
+  - 7.2
 
 before_script:
   - cp .env.travis .env
-  - composer self-update
   - composer install --no-interaction
-
-script:
   - php artisan key:generate
-  - vendor/bin/phpunit
 
 services:
   - redis-server


### PR DESCRIPTION
Since [phpunit runs as default script](https://docs.travis-ci.com/user/languages/php/#Default-Build-Script) and composer self-update also runs automatically I remove this from configs to make it cleaner. And also add php 7.2