### PR TITLE
Removed obsolte ref properties remained from refactoring

### DIFF
--- a/resources/assets/js/components/Reply.vue
+++ b/resources/assets/js/components/Reply.vue
@@ -26,7 +26,7 @@
                 </form>
             </div>
 
-            <div ref="body" v-else>
+            <div v-else>
                 <highlight :content="body"></highlight>
             </div>
         </div>

--- a/resources/views/threads/_question.blade.php
+++ b/resources/views/threads/_question.blade.php
@@ -50,7 +50,7 @@
         </div>
     </div>
 
-    <div ref="question" class="panel-body">
+    <div class="panel-body">
         <highlight :content="body"></highlight>
     </div>
 


### PR DESCRIPTION
After your refactor the ref property is no more needed outside from the new highlight component.