### PR TITLE
Renamed computed property for filtered channels

### DIFF
--- a/resources/assets/js/components/ChannelDropdown.vue
+++ b/resources/assets/js/components/ChannelDropdown.vue
@@ -18,7 +18,7 @@
             </div>
 
             <ul class="list-group channel-list">
-                <li class="list-group-item" v-for="channel in filteredThreads">
+                <li class="list-group-item" v-for="channel in filteredChannels">
                     <a :href="`/threads/${channel.slug}`" v-text="channel.name"></a>
                 </li>
             </ul>
@@ -60,7 +60,7 @@
         },
 
         computed: {
-            filteredThreads() {
+            filteredChannels() {
                 return this.channels.filter(channel => {
                     return channel.name.toLowerCase().startsWith(this.filter.toLocaleLowerCase())
                 });


### PR DESCRIPTION
I just renamed a computed property from filteredThreads to filteredChannels.

I know, it's a small change but I think this makes more sense.