### PR TITLE
An administrator can 'Pin' Threads

### DIFF
--- a/app/Http/Controllers/PinnedThreadsController.php
+++ b/app/Http/Controllers/PinnedThreadsController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Thread;
+
+class PinnedThreadsController extends Controller
+{
+    /**
+     * Pin the given thread.
+     *
+     * @param \App\Thread $thread
+     */
+    public function store(Thread $thread)
+    {
+        $thread->update(['pinned' => true]);
+    }
+
+    /**
+     * Un-Pin the given thread.
+     *
+     * @param \App\Thread $thread
+     */
+    public function destroy(Thread $thread)
+    {
+        $thread->update(['pinned' => false]);
+    }
+}

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -148,7 +148,9 @@ class ThreadsController extends Controller
      */
     protected function getThreads(Channel $channel, ThreadFilters $filters)
     {
-        $threads = Thread::latest()->filter($filters);
+        $threads = Thread::orderBy('pinned', 'DESC')
+            ->latest()
+            ->filter($filters);
 
         if ($channel->exists) {
             $threads->where('channel_id', $channel->id);

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -40,7 +40,8 @@ class Thread extends Model
      * @var array
      */
     protected $casts = [
-        'locked' => 'boolean'
+        'locked' => 'boolean',
+        'pinned' => 'boolean'
     ];
 
     /**

--- a/database/migrations/2017_03_15_175959_create_threads_table.php
+++ b/database/migrations/2017_03_15_175959_create_threads_table.php
@@ -24,6 +24,7 @@ class CreateThreadsTable extends Migration
             $table->text('body');
             $table->unsignedInteger('best_reply_id')->nullable();
             $table->boolean('locked')->default(false);
+            $table->boolean('pinned')->default(false);
             $table->timestamps();
 
             $table->foreign('best_reply_id')

--- a/resources/assets/js/pages/Thread.vue
+++ b/resources/assets/js/pages/Thread.vue
@@ -12,6 +12,7 @@
             return {
                 repliesCount: this.thread.replies_count,
                 locked: this.thread.locked,
+                pinned: this.thread.pinned,
                 title: this.thread.title,
                 body: this.thread.body,
                 form: {},
@@ -22,7 +23,7 @@
         created () {
             this.resetForm();
         },
-        
+
         methods: {
             toggleLock () {
                 let uri = `/locked-threads/${this.thread.slug}`;
@@ -30,6 +31,14 @@
                 axios[this.locked ? 'delete' : 'post'](uri);
 
                 this.locked = ! this.locked;
+            },
+
+            togglePin () {
+                let uri = `/pinned-threads/${this.thread.slug}`;
+
+                axios[this.pinned ? 'delete' : 'post'](uri);
+
+                this.pinned = ! this.pinned;
             },
 
             update () {
@@ -51,6 +60,13 @@
                 };
 
                 this.editing = false;
+            },
+
+            classes(target) {
+                return [
+                    'btn',
+                    target ? 'btn-primary' : 'btn-default'
+                ];
             }
         }
     }

--- a/resources/views/threads/_list.blade.php
+++ b/resources/views/threads/_list.blade.php
@@ -5,7 +5,7 @@
                 <div class="flex">
                     <h4>
                         <a href="{{ $thread->path() }}">
-                            @if($thread->pinned)
+                            @if ($thread->pinned)
                                 <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
                             @endif
                             @if (auth()->check() && $thread->hasUpdatesFor(auth()->user()))

--- a/resources/views/threads/_list.blade.php
+++ b/resources/views/threads/_list.blade.php
@@ -5,6 +5,9 @@
                 <div class="flex">
                     <h4>
                         <a href="{{ $thread->path() }}">
+                            @if($thread->pinned)
+                                <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+                            @endif
                             @if (auth()->check() && $thread->hasUpdatesFor(auth()->user()))
                                 <strong>
                                     {{ $thread->title }}

--- a/resources/views/threads/show.blade.php
+++ b/resources/views/threads/show.blade.php
@@ -28,10 +28,15 @@
                             <p>
                                 <subscribe-button :active="{{ json_encode($thread->isSubscribedTo) }}" v-if="signedIn"></subscribe-button>
 
-                                <button class="btn btn-default"
+                                <button :class="classes(locked)"
                                         v-if="authorize('isAdmin')"
                                         @click="toggleLock"
                                         v-text="locked ? 'Unlock' : 'Lock'"></button>
+
+                                <button :class="classes(pinned)"
+                                        v-if="authorize('isAdmin')"
+                                        @click="togglePin"
+                                        v-text="pinned ? 'Unpin' : 'Pin'"></button>
                             </p>
                         </div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,9 @@ Route::get('threads/{channel}', 'ThreadsController@index')->name('channels');
 Route::post('locked-threads/{thread}', 'LockedThreadsController@store')->name('locked-threads.store')->middleware('admin');
 Route::delete('locked-threads/{thread}', 'LockedThreadsController@destroy')->name('locked-threads.destroy')->middleware('admin');
 
+Route::post('pinned-threads/{thread}', 'PinnedThreadsController@store')->name('pinned-threads.store')->middleware('admin');
+Route::delete('pinned-threads/{thread}', 'PinnedThreadsController@destroy')->name('pinned-threads.destroy')->middleware('admin');
+
 Route::get('/threads/{channel}/{thread}/replies', 'RepliesController@index')->name('replies');
 Route::post('/threads/{channel}/{thread}/replies', 'RepliesController@store')->middleware('must-be-confirmed')->name('replies.store');
 Route::patch('/replies/{reply}', 'RepliesController@update')->name('replies.update');

--- a/tests/Feature/PinThreadsTest.php
+++ b/tests/Feature/PinThreadsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Channel;
+use App\Thread;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PinThreadsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function administrators_can_pin_threads()
+    {
+        $this->signInAdmin();
+
+        $thread = create('App\Thread');
+
+        $this->post(route('pinned-threads.store', $thread));
+
+        $this->assertTrue($thread->fresh()->pinned, 'Failed asserting that the thread was pinned.');
+    }
+
+    /** @test */
+    public function administrators_can_unpin_threads()
+    {
+        $this->signInAdmin();
+
+        $thread = create('App\Thread', ['pinned' => true]);
+
+        $this->delete(route('pinned-threads.destroy', $thread));
+
+        $this->assertFalse($thread->fresh()->pinned, 'Failed asserting that the thread was unlocked.');
+    }
+
+    /** @test */
+    public function pinned_threads_are_listed_first()
+    {
+        $channel = create(Channel::class, [
+            'name' => 'PHP',
+            'slug' => 'php'
+        ]);
+
+        create(Thread::class, ['channel_id' => $channel->id]);
+        create(Thread::class, ['channel_id' => $channel->id]);
+        $threadToPin = create(Thread::class, ['channel_id' => $channel->id]);
+
+        $this->signInAdmin();
+
+        $response = $this->getJson(route('threads'));
+        $response->assertJson([
+            'data' => [
+                ['id' => '1'],
+                ['id' => '2'],
+                ['id' => '3'],
+            ]
+        ]);
+
+        $this->post(route('pinned-threads.store', $threadToPin));
+
+        $response = $this->getJson(route('threads'));
+        $response->assertJson([
+            'data' => [
+                ['id' => '3'],
+                ['id' => '1'],
+                ['id' => '2'],
+            ]
+        ]);
+
+    }
+}


### PR DESCRIPTION
Many forums have the ability to 'Pin' threads to the top of a list of threads. This PR introduces that feature,

- Administrators can pin and unpin threads.
- Pinned threads are displayed at the top of the Thread listings with a pin icon.

If anybody has any thoughts on `tests/Feature/PinThreadsTest@pinned_threads_are_listed_first()` i'd like to hear them. I'm not 100% happy with how its implemented.
