### PR TITLE
Fix notifications not marked read

### DIFF
--- a/app/Http/Controllers/UserNotificationsController.php
+++ b/app/Http/Controllers/UserNotificationsController.php
@@ -30,6 +30,12 @@ class UserNotificationsController extends Controller
      */
     public function destroy($user, $notificationId)
     {
-        auth()->user()->notifications()->findOrFail($notificationId)->markAsRead();
+        $notification = auth()->user()->notifications()->findOrFail($notificationId);
+
+        $notification->markAsRead();
+
+        return json_encode(
+            $notification->data['link']
+        );
     }
 }

--- a/resources/assets/js/components/UserNotifications.vue
+++ b/resources/assets/js/components/UserNotifications.vue
@@ -18,12 +18,12 @@
 <script>
     export default {
         data() {
-            return { notifications: false };
+            return { notifications: false }
         },
 
         created() {
             axios.get('/profiles/' + window.App.user.name + '/notifications')
-              .then(response => this.notifications = response.data);
+                .then(response => this.notifications = response.data);
         },
 
         methods: {
@@ -32,5 +32,5 @@
                 .then(response => window.location.href = response.data);
             }
         }
-    };
+    }
 </script>

--- a/resources/assets/js/components/UserNotifications.vue
+++ b/resources/assets/js/components/UserNotifications.vue
@@ -8,7 +8,7 @@
             <li v-for="notification in notifications">
                 <a :href="notification.data.link"
                    v-text="notification.data.message"
-                   @click="markAsRead(notification)"
+                   @click.prevent="markAsRead(notification)"
                 ></a>
             </li>
         </ul>
@@ -18,18 +18,19 @@
 <script>
     export default {
         data() {
-            return { notifications: false }
+            return { notifications: false };
         },
 
         created() {
             axios.get('/profiles/' + window.App.user.name + '/notifications')
-                .then(response => this.notifications = response.data);
+              .then(response => this.notifications = response.data);
         },
 
         methods: {
             markAsRead(notification) {
                 axios.delete('/profiles/' + window.App.user.name + '/notifications/' + notification.id)
+                .then(response => window.location.href = response.data);
             }
         }
-    }
+    };
 </script>


### PR DESCRIPTION
When a user has notifications and they click the notification to see the mention, they correctly navigate to the mention but the notification is not marked as read—This PR fixes that.