### PR TITLE
Adds uniqueness validation for user's name during registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -51,7 +51,7 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => 'required|max:255',
+            'name' => 'required|max:255|unique:users',
             'email' => 'required|email|max:255|unique:users',
             'password' => 'required|min:6|confirmed',
         ]);


### PR DESCRIPTION
Trying to register a user with a name that is already registered throws a QueryException since the name field in users table has a unique constraint. This pull request fixes it by adding the unique validation for name field while registering a user.