### PR TITLE
Separate sorted and active global scopes

### DIFF
--- a/app/Channel.php
+++ b/app/Channel.php
@@ -25,8 +25,11 @@ class Channel extends Model
         parent::boot();
 
         static::addGlobalScope('active', function ($builder) {
-            $builder->where('archived', false)
-                ->orderBy('name', 'asc');
+            $builder->where('archived', false);
+        });
+
+        static::addGlobalScope('sorted', function ($builder) {
+            $builder->orderBy('name', 'asc');
         });
     }
 

--- a/app/Channel.php
+++ b/app/Channel.php
@@ -20,6 +20,9 @@ class Channel extends Model
         'archived' => 'boolean'
     ];
 
+    /**
+     * Boot the channels model.
+     */
     protected static function boot()
     {
         parent::boot();
@@ -70,5 +73,13 @@ class Channel extends Model
     {
         $this->attributes['name'] = $name;
         $this->attributes['slug'] = str_slug($name);
+    }
+
+    /**
+     * Get a new query builder that includes archives.
+     */
+    public static function withArchived()
+    {
+        return (new static)->newQueryWithoutScope('active');
     }
 }

--- a/app/Http/Controllers/Admin/ChannelsController.php
+++ b/app/Http/Controllers/Admin/ChannelsController.php
@@ -15,7 +15,7 @@ class ChannelsController extends Controller
      */
     public function index()
     {
-        $channels = Channel::withoutGlobalScopes()->orderBy('name', 'asc')->with('threads')->get();
+        $channels = Channel::withoutGlobalScope('active')->with('threads')->get();
 
         return view('admin.channels.index', compact('channels'));
     }

--- a/app/Http/Controllers/Admin/ChannelsController.php
+++ b/app/Http/Controllers/Admin/ChannelsController.php
@@ -15,7 +15,7 @@ class ChannelsController extends Controller
      */
     public function index()
     {
-        $channels = Channel::withoutGlobalScope('active')->with('threads')->get();
+        $channels = Channel::withArchived()->with('threads')->get();
 
         return view('admin.channels.index', compact('channels'));
     }

--- a/tests/Unit/ChannelTest.php
+++ b/tests/Unit/ChannelTest.php
@@ -4,12 +4,28 @@ namespace Tests\Feature;
 
 use App\Channel;
 use Tests\TestCase;
+use PHPUnit\Framework\Assert;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class ChannelTest extends TestCase
 {
     use RefreshDatabase;
-    
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        EloquentCollection::macro('assertEquals', function ($items) {
+            Assert::assertEquals(count($this), count($items));
+
+            $this->zip($items)->each(function ($pair) {
+                list($a, $b) = $pair;
+                Assert::assertTrue($a->is($b));
+            });
+        });
+    }
+
     /** @test */
     public function a_channel_consists_of_threads()
     {
@@ -38,5 +54,21 @@ class ChannelTest extends TestCase
         create('App\Channel', ['archived' => true]);
 
         $this->assertEquals(1, Channel::count());
+    }
+
+    /** @test */
+    public function channels_are_sorted_alphabetically_by_default()
+    {
+        $channelA = create('App\Channel', ['name' => 'PHP']);
+        $channelB = create('App\Channel', ['name' => 'Basic']);
+        $channelC = create('App\Channel', ['name' => 'Zsh']);
+
+        $channels = Channel::all();
+
+        $channels->assertEquals([
+            $channelB,
+            $channelA,
+            $channelC,
+        ]);
     }
 }


### PR DESCRIPTION
This is a fairly straight forward refactor to pull the sorting out of the 'active' global scope, since the two issues are unrelated.

This lets us test and refactor the sorting of the channels independent of the active/archived state. As well we don't have the somewhat strange situation in Admin\ChannelsController where we're striping the sort order off with withoutGlobalScopes() only to add it right back on. 

I created a macro on the Eloquent Collection to cleanly test sort order (ala Adam W.). This could be pulled up into TestCase if its useful in other tests.