### PR TITLE
Use withCount to optimise queries

### DIFF
--- a/app/Http/Controllers/Admin/ChannelsController.php
+++ b/app/Http/Controllers/Admin/ChannelsController.php
@@ -15,7 +15,7 @@ class ChannelsController extends Controller
      */
     public function index()
     {
-        $channels = Channel::withoutGlobalScopes()->orderBy('name', 'asc')->with('threads')->get();
+        $channels = Channel::withoutGlobalScopes()->orderBy('name', 'asc')->withCount('threads')->get();
 
         return view('admin.channels.index', compact('channels'));
     }

--- a/resources/views/admin/channels/index.blade.php
+++ b/resources/views/admin/channels/index.blade.php
@@ -24,7 +24,7 @@
                     <td>{{$channel->name}}</td>
                     <td>{{$channel->slug}}</td>
                     <td>{{$channel->description}}</td>
-                    <td>{{$channel->threads()->count()}}</td>
+                    <td>{{$channel->threads_count}}</td>
                     <td>
                         <a href="{{ route('admin.channels.edit', ['channel' => $channel->slug]) }}" class="btn btn-default btn-xs">Edit</a>
                     </td>


### PR DESCRIPTION
This PR simply optimisees queries on the Admin Channels index view by (i) eager-loading threads count rather than whole Thread objects and (ii) replacing N+1 queries in the view with the eager-loaded count