### PR TITLE
Removing unnecessary appends property on Thread

### DIFF
--- a/app/Thread.php
+++ b/app/Thread.php
@@ -28,13 +28,6 @@ class Thread extends Model
     protected $with = ['creator', 'channel'];
 
     /**
-     * The accessors to append to the model's array form.
-     *
-     * @var array
-     */
-    protected $appends = ['isSubscribedTo'];
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array


### PR DESCRIPTION
The thread's `isSubscribedTo` accessor property is not used by our Vue app (currently), so removing the automatic `$appends` reduces N queries on the threads.index view.