### PR TITLE
Use more semantic class to indicate archived channels

### DIFF
--- a/resources/views/admin/channels/index.blade.php
+++ b/resources/views/admin/channels/index.blade.php
@@ -20,7 +20,7 @@
 
         <tbody>
             @forelse($channels as $channel)
-                <tr class="{{ $channel->archived ? 'info' : '' }}">
+                <tr class="{{ $channel->archived ? 'danger' : '' }}">
                     <td>{{$channel->name}}</td>
                     <td>{{$channel->slug}}</td>
                     <td>{{$channel->description}}</td>


### PR DESCRIPTION
This may just be a matter of opinion, but to me archiving is almost akin to a soft delete; we want to remove the channel from use, but keep the content around for historical purposes.

Using the danger class on the table row is, in my opinion, slightly more semantic and serves as a better indicator that the channel is archived.