### PR TITLE
fix a bug when trying to get path of a thread in an archived channel.

### DIFF
--- a/app/Thread.php
+++ b/app/Thread.php
@@ -101,7 +101,7 @@ class Thread extends Model
      */
     public function channel()
     {
-        return $this->belongsTo(Channel::class);
+        return $this->belongsTo(Channel::class)->withoutGlobalScope('active');
     }
 
     /**

--- a/tests/Feature/Admin/ChannelAdministrationTest.php
+++ b/tests/Feature/Admin/ChannelAdministrationTest.php
@@ -93,6 +93,21 @@ class ChannelAdministrationTest extends TestCase
 
         $this->assertTrue($channel->fresh()->archived);
     }
+    
+    /** @test */
+    public function archive_channel_should_not_influence_existing_thread()
+    {
+        $this->signInAdmin();
+        $channel = create('App\Channel');
+        $thread = create('App\Thread', ['channel_id' => $channel->id]);
+        $path = $thread->path();
+
+        $channel->update([
+            'archived' => true
+        ]);
+
+        $this->assertEquals($path, $thread->fresh()->path());
+    }
 
     /** @test */
     public function a_channel_requires_a_name()


### PR DESCRIPTION
right now, call 'path()' on a thread in an archived channel will throw an error. 
This PR fixes it.
