### PR TITLE
Disallow new threads in archived channels

### DIFF
--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -7,6 +7,7 @@ use App\Channel;
 use App\Trending;
 use App\Rules\Recaptcha;
 use App\Filters\ThreadFilters;
+use Illuminate\Validation\Rule;
 
 class ThreadsController extends Controller
 {
@@ -63,7 +64,12 @@ class ThreadsController extends Controller
         request()->validate([
             'title' => 'required|spamfree',
             'body' => 'required|spamfree',
-            'channel_id' => 'required|exists:channels,id',
+            'channel_id' => [
+                'required',
+                Rule::exists('channels', 'id')->where(function ($query) {
+                    $query->where('archived', false);
+                }),
+            ],
             'g-recaptcha-response' => ['required', $recaptcha]
         ]);
 

--- a/tests/Feature/CreateThreadsTest.php
+++ b/tests/Feature/CreateThreadsTest.php
@@ -155,6 +155,23 @@ class CreateThreadsTest extends TestCase
         $this->assertEquals(0, Activity::count());
     }
 
+    /** @test */
+    function a_new_thread_cannot_be_created_in_an_archived_channel()
+    {
+        $channel = factory('App\Channel')->create();
+
+        $response = $this->publishThread(['title' => 'Some Title', 'body' => 'Some body.']);
+
+        $this->get($response->headers->get('Location'))
+            ->assertSee('Some Title')
+            ->assertSee('Some body.');
+
+        $channel->archive();
+
+        $this->publishThread(['channel_id' => $channel->id])
+            ->assertSessionHasErrors('channel_id');
+    }
+
     protected function publishThread($overrides = [])
     {
         $this->withExceptionHandling()->signIn();


### PR DESCRIPTION
While a user will not see archived channels on the front end when creating threads, they can submit a POST request behind the scenes with an archived channel id and it will work.  This commit blocks that, which I believe is the intended behavior.