### PR TITLE
Admins can activate archived channels - resolves #157.

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -23,9 +23,11 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
-
         parent::boot();
+
+        Route::bind('any_channel', function ($slug) {
+            return \App\Channel::withoutGlobalScopes()->where('slug', $slug)->firstOrFail();
+        });
     }
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,6 +64,6 @@ Route::group([
     Route::post('/channels', 'ChannelsController@store')->name('admin.channels.store');
     Route::get('/channels', 'ChannelsController@index')->name('admin.channels.index');
     Route::get('/channels/create', 'ChannelsController@create')->name('admin.channels.create');
-    Route::get('/channels/{channel}/edit', 'ChannelsController@edit')->name('admin.channels.edit');
-    Route::patch('/channels/{channel}', 'ChannelsController@update')->name('admin.channels.update');
+    Route::get('/channels/{any_channel}/edit', 'ChannelsController@edit')->name('admin.channels.edit');
+    Route::patch('/channels/{any_channel}', 'ChannelsController@update')->name('admin.channels.update');
 });

--- a/tests/Feature/Admin/ChannelAdministrationTest.php
+++ b/tests/Feature/Admin/ChannelAdministrationTest.php
@@ -95,6 +95,40 @@ class ChannelAdministrationTest extends TestCase
     }
 
     /** @test */
+    public function an_administrator_can_edit_an_archived_channel()
+    {
+        $this->signInAdmin();
+
+        $channel = create('App\Channel', ['archived' => true]);
+
+        $this->assertTrue($channel->archived);
+
+        $this->get(route('admin.channels.edit', ['channel' => $channel->slug]))
+            ->assertStatus(Response::HTTP_OK);
+    }
+
+    /** @test */
+    public function an_administrator_can_activate_an_archived_channel()
+    {
+        $this->signInAdmin();
+
+        $channel = create('App\Channel', ['archived' => true]);
+
+        $this->assertTrue($channel->archived);
+
+        $this->patch(
+            route('admin.channels.update', ['channel' => $channel->slug]),
+            [
+                'name' => 'altered',
+                'description' => 'altered channel description',
+                'archived' => false
+            ]
+        );
+
+        $this->assertFalse($channel->fresh()->archived);
+    }
+
+    /** @test */
     public function a_channel_requires_a_name()
     {
         $this->createChannel(['name' => null])


### PR DESCRIPTION
Not sure if the `RouteServiceProvider` approach is really the cleanest, but I think I prefer it to doing `withoutGlobalScopes()` in two places.

Cheers!