### PR TITLE
Remove unused clearReputation method.

### DIFF
--- a/app/HasReputation.php
+++ b/app/HasReputation.php
@@ -5,18 +5,6 @@ namespace App;
 trait HasReputation
 {
     /**
-     * Clear user reputation.
-     *
-     * @return void
-     */
-    public function clearReputation()
-    {
-        $this->reputation = 0;
-
-        $this->save();
-    }
-
-    /**
      * Award reputation points to the model.
      *
      * @param  string $action


### PR DESCRIPTION
This method was added when the Trait HasReputation was created but is
never used in the application or tests.