### PR TITLE
Fix password database empty during install

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -147,7 +147,7 @@ class InstallCommand extends Command
      */
     public function askHiddenWithDefault($question, $fallback = true)
     {
-        $question = new Question($question, 'NULL');
+        $question = new Question($question, 'null');
 
         $question->setHidden(true)->setHiddenFallback($fallback);
 


### PR DESCRIPTION
During installation, if I leave blank for no password

in the file you will have `NULL`

and for the migration we expect to have `null` for no password

so migration will failed because the credentials will be NULL password instead of no password at all.