### PR TITLE
Save content of the body input if validation fails

### DIFF
--- a/resources/views/threads/create.blade.php
+++ b/resources/views/threads/create.blade.php
@@ -36,7 +36,7 @@
 
                             <div class="form-group">
                                 <label for="body">Body:</label>
-                                <wysiwyg name="body"></wysiwyg>
+                                <wysiwyg name="body" value="{{ old('body') }}"></wysiwyg>
                             </div>
 
                             <div class="form-group">


### PR DESCRIPTION
E.g. user does not provide a title or click the reCAPTCHA when creating a new thread.