### PR TITLE
Use getRouteKeyName() instead of hardcoded string

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -25,8 +25,8 @@ class RouteServiceProvider extends ServiceProvider
     {
         parent::boot();
 
-        Route::bind('channel', function ($slug) {
-            return \App\Channel::withArchived()->where('slug', $slug)->firstOrFail();
+        Route::bind('channel', function ($key) {
+            return \App\Channel::withArchived()->where((new \App\Channel)->getRouteKeyName(), $key)->firstOrFail();
         });
     }
 


### PR DESCRIPTION
In the rare case we would change the route key of the channel model, we would have to remember to also change this in the RouteServiceProvider.

Not sure about creating a new instance each time, but getRouteKeyName() cannot be called statically.