### PR TITLE
Add a filter to show only active threads

### DIFF
--- a/app/Filters/ThreadFilters.php
+++ b/app/Filters/ThreadFilters.php
@@ -11,7 +11,7 @@ class ThreadFilters extends Filters
      *
      * @var array
      */
-    protected $filters = ['by', 'popular', 'unanswered'];
+    protected $filters = ['by', 'popular', 'unanswered', 'active'];
 
     /**
      * Filter the query by a given username.
@@ -46,5 +46,15 @@ class ThreadFilters extends Filters
     protected function unanswered()
     {
         return $this->builder->where('replies_count', 0);
+    }
+
+    /**
+     * Filter the query include only threads on active channels.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function active($bool)
+    {
+        return $this->builder->join('channels', 'channel_id', '=', 'channels.id')->where('channels.archived', false);
     }
 }

--- a/resources/views/layouts/nav.blade.php
+++ b/resources/views/layouts/nav.blade.php
@@ -33,6 +33,7 @@
 
                         <li><a href="/threads?popular=1">Popular Threads</a></li>
                         <li><a href="/threads?unanswered=1">Unanswered Threads</a></li>
+                        <li><a href="/threads?active=1">Active Threads</a></li>
                     </ul>
                 </li>
 

--- a/tests/Feature/ReadThreadsTest.php
+++ b/tests/Feature/ReadThreadsTest.php
@@ -85,6 +85,16 @@ class ReadThreadsTest extends TestCase
     }
 
     /** @test */
+    function a_user_can_filter_threads_to_show_only_active_threads()
+    {
+        $this->thread->channel->archive();
+
+        $response = $this->getJson('threads?active=1')->json();
+
+        $this->assertCount(0, $response['data']);
+    }
+
+    /** @test */
     function a_user_can_request_all_replies_for_a_given_thread()
     {
         $thread = create('App\Thread');


### PR DESCRIPTION
Maybe this should even be the default view, as we don't "delete" channels (with their threads), but archive them, which should remove them from the default view.
It might then be a good idea to allow only admins to view all threads (or filter by archived threads). Links to archived threads aren't affected, as maybe a search engine result would still point to them.

I'm not sure if this is the proper way to filter threads by archived channels, maybe there is a more elegant way to join the threads table with the channels table and apply the filter.

*tests/Feature/ReadThreadsTest.php:
    setUp()-method already creates a thread, using its channel