### PR TITLE
Fix failing tests in design branch.

### DIFF
--- a/app/Http/Controllers/Admin/ChannelsController.php
+++ b/app/Http/Controllers/Admin/ChannelsController.php
@@ -15,9 +15,9 @@ class ChannelsController extends Controller
      */
     public function index()
     {
-        $channels = Channel::withArchived()->with('threads')->get();
+        $allChannels = Channel::withArchived()->with('threads')->get();
 
-        return view('admin.channels.index', compact('channels'));
+        return view('admin.channels.index', compact('allChannels'));
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,8 +16,10 @@ class AppServiceProvider extends ServiceProvider
     {
         \Validator::extend('spamfree', 'App\Rules\SpamFree@passes');
 
-        view()->share('channels', \App\Channel::all());
-        view()->share('trending', $trending->get());
+        \View::composer('*', function ($view) use ($trending) {
+            $view->with('channels', \App\Channel::all())
+                ->with('trending', $trending->get());
+        });
     }
 
     /**

--- a/resources/views/admin/channels/index.blade.php
+++ b/resources/views/admin/channels/index.blade.php
@@ -19,7 +19,7 @@
         </thead>
 
         <tbody>
-            @forelse($channels as $channel)
+            @forelse($allChannels as $channel)
                 <tr class="{{ $channel->archived ? 'danger' : '' }}">
                     <td>{{$channel->name}}</td>
                     <td>{{$channel->slug}}</td>

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -20,11 +20,11 @@ class UserTest extends TestCase
     }
 
     /** @test */
-    function a_user_can_determine_their_avatar_path()
+    public function a_user_can_determine_their_avatar_path()
     {
         $user = create('App\User');
 
-        $this->assertEquals(asset('images/avatars/default.png'), $user->avatar_path);
+        $this->assertEquals(asset('images/avatars/default.svg'), $user->avatar_path);
 
         $user->avatar_path = 'avatars/me.jpg';
 


### PR DESCRIPTION
This PR fixes the entire test suite that is failing globally. It also fixes two individual tests that were failing due to changes in the design branch.

- Fix global failure of all tests due to `\App\Channel::all()` being called on application boot when the database has not been migrated yet.
- Correct UserTest to check for 'default.svg' instead of 'default.png'.
- Stop channels injected by View Composer in `app/Providers/AppServiceProvider.php` overwriting the channels provided by `app/Http/Controllers/Admin/ChannelsController`.
