### PR TITLE
Improve seeding with realistic users, channels, visit counts and activity.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Trending;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -12,7 +11,7 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot(Trending $trending)
+    public function boot()
     {
         \Validator::extend('spamfree', 'App\Rules\SpamFree@passes');
     }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -49,6 +49,24 @@ $factory->define(App\Thread::class, function ($faker) {
     ];
 });
 
+$factory->state(App\Thread::class, 'from_existing_channels_and_users', function ($faker) {
+    $title = $faker->sentence;
+
+    return [
+        'user_id' => function () {
+            return \App\User::all()->random()->id;
+        },
+        'channel_id' => function () {
+            return \App\Channel::all()->random()->id;
+        },
+        'title' => $title,
+        'body'  => $faker->paragraph,
+        'visits' => $faker->numberBetween(0, 35),
+        'slug' => str_slug($title),
+        'locked' => $faker->boolean(15)
+    ];
+});
+
 $factory->define(App\Channel::class, function ($faker) {
     return [
         'name' => $faker->unique()->word,

--- a/database/seeds/UsersSeeder.php
+++ b/database/seeds/UsersSeeder.php
@@ -14,12 +14,40 @@ class UsersSeeder extends Seeder
     {
         User::truncate();
 
-        factory(User::class)
-            ->create([
+        collect([
+            [
                 'name' => 'John Doe',
                 'username' => 'johndoe',
                 'email' => 'john@example.com',
                 'password' => bcrypt('password')
-            ]);
+            ],
+            [
+                'name' => 'Indiana Jones',
+                'username' => 'rotla1981',
+                'email' => 'indy@example.com',
+                'password' => bcrypt('password')
+            ],
+            [
+                'name' => 'Ben Solo',
+                'username' => 'KyloRen',
+                'email' => 'kylo@example.com',
+                'password' => bcrypt('password')
+            ],
+            [
+                'name' => 'Marty McFly',
+                'username' => '121gigawatts',
+                'email' => 'calvin@example.com',
+                'password' => bcrypt('password')
+            ],
+        ])->each(function ($user) {
+            factory(User::class)->create(
+                [
+                    'name' => $user['name'],
+                    'username' => $user['username'],
+                    'email' => $user['email'],
+                    'password' => bcrypt('password')
+                ]
+            );
+        });
     }
 }

--- a/resources/views/threads/_question.blade.php
+++ b/resources/views/threads/_question.blade.php
@@ -52,9 +52,13 @@
                 <span v-if="! editing">
                     <span v-if="(authorize('isAdmin') || authorize('owns', thread))">
                         <a href="#" class="text-blue link pl-2 ml-2 border-l" @click.prevent="editing = true">Edit</a>
-                        <a href="#" class="link pl-2 ml-2 border-l" :class="locked ? 'font-bold' : ''" @click.prevent="toggleLock" v-text="locked ? 'Unlock' : 'Lock'"></a>
-                        <a href="#" class="link pl-2 ml-2 border-l" :class="pinned ? 'font-bold' : ''" @click.prevent="togglePin" v-text="pinned ? 'Unpin' : 'Pin'"></a>
+
+                        <span v-if="authorize('isAdmin')">
+                            <a href="#" class="link pl-2 ml-2 border-l" :class="locked ? 'font-bold' : ''" @click.prevent="toggleLock" v-text="locked ? 'Unlock' : 'Lock'"></a>
+                            <a href="#" class="link pl-2 ml-2 border-l" :class="pinned ? 'font-bold' : ''" @click.prevent="togglePin" v-text="pinned ? 'Unpin' : 'Pin'"></a>
+                        </span>
                     </span>
+
                     <subscribe-button :active="{{ json_encode($thread->isSubscribedTo) }}" v-if="signedIn"></subscribe-button>
                 </span>
             </p>


### PR DESCRIPTION
This PR changes the seeders to create a more realistic feeling forum. 

- Four users are created.
- Realistic channels are created (Eloquent, Laravel Mix, PHP, VueEx and VueJS )
- The seeded threads are assigned to the existing channels and users (currently new users and channels are created for each thread).
- Each thread is seeded with a visit count
- A seeded thread may be locked (there is a 15% chance a thread will be created locked)
- Thread creation activity is recorded so that user profiles are correct (currently seeded users have no activity)

![screenshot-2018-2-15 council](https://user-images.githubusercontent.com/1974648/36273580-d13f44c8-127c-11e8-8482-b3f4cb9ad134.png)
