### PR TITLE
Remove unneeded param on App Service Provider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,7 +12,7 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot(Trending $trending)
+    public function boot()
     {
         \Validator::extend('spamfree', 'App\Rules\SpamFree@passes');
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Trending;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider


### PR DESCRIPTION
I've removed the `$trending` param on the boot method as it is no longer used.