### PR TITLE
Quick Bug Fix: Reply now references correct dynamic link to user's profile

### DIFF
--- a/resources/assets/js/components/Reply.vue
+++ b/resources/assets/js/components/Reply.vue
@@ -17,7 +17,7 @@
                 <div class="flex items-center mb-6 mt-2">
                     <div class="flex flex-1">
                         <h5 class="font-normal">
-                            <a class="text-blue font-bold link" :href="'/profiles/' + reply.owner.name" v-text="reply.owner.name"></a>
+                            <a class="text-blue font-bold link" :href="'/profiles/' + reply.owner.username" v-text="reply.owner.name"></a>
                         </h5>
 
                         <a v-if="! editing && (authorize('owns', reply) || authorize('owns', reply.thread))"


### PR DESCRIPTION
When you click on reply creator's name, it redirects you to `/profile/name` instead of `/profile/username`. This PR fixes the issue.