### PR TITLE
Don't show create new thread modal for non confirmed users

### DIFF
--- a/resources/views/modals/all.blade.php
+++ b/resources/views/modals/all.blade.php
@@ -1,3 +1,3 @@
-@include('modals.new-thread')
+@includeWhen(auth()->check() && auth()->user()->confirmed, 'modals.new-thread')
 @include('modals.login')
 @include('modals.register')

--- a/resources/views/sidebar.blade.php
+++ b/resources/views/sidebar.blade.php
@@ -3,7 +3,11 @@
 
     <div class="widget border-b-0">
         @if (auth()->check())
-            <button class="btn is-green w-full" @click="$modal.show('new-thread')">Add New Thread</button>
+            @if(auth()->user()->confirmed)
+                <button class="btn is-green w-full" @click="$modal.show('new-thread')">Add New Thread</button>
+            @else
+                <button class="btn w-full">Please confirm your email address</button>
+            @endif
         @else
             <button class="btn is-green w-full tracking-wide" @click="$modal.show('login')">Log In To Post</button>
         @endif


### PR DESCRIPTION
I've updated the create a new thread button to only be accessible to users that have been confirmed, I've also updated the `all.blade.php` to be `includeWhen`. I was also tempted to do the same for the login and register modals, but I thought that'd be best to do in a separate PR.

![image](https://user-images.githubusercontent.com/916500/36342269-c749849c-13f3-11e8-824c-b7b791ecb7a1.png)
