### PR TITLE
Case insensitive comparison against config admins

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -109,7 +109,11 @@ class User extends Authenticatable
      */
     public function isAdmin()
     {
-        return in_array($this->email, config('council.administrators'));
+        return in_array(
+            strtolower($this->email),
+            array_map('strtolower', config('council.administrators')
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
`in_array()` is used for case-sensitive comparison which means the email address stored in the database `admin@example.com` isn't equal to the `Admin@example.com` stored in council config.

What we need here is the case-insensitive comparison in case we change cases while adding emails in council config file.
