### PR TITLE
[ wip ] — Style the users profile page

### DIFF
--- a/app/Activity.php
+++ b/app/Activity.php
@@ -13,6 +13,20 @@ class Activity extends Model
      */
     protected $guarded = [];
 
+    protected $appends = ['favoritedModel'];
+
+    public function getFavoritedModelAttribute()
+    {
+        $favoritedModel = null;
+        if ($this->subject_type === Favorite::class) {
+            $subject = $this->subject()->firstOrFail();
+            if ($subject->favorited_type == Reply::class) {
+                $favoritedModel = Reply::find($subject->favorited_id);
+            }
+        }
+        return $favoritedModel;
+    }
+
     /**
      * Fetch the associated subject for the activity.
      *
@@ -40,5 +54,20 @@ class Activity extends Model
             ->groupBy(function ($activity) {
                 return $activity->created_at->format('Y-m-d');
             });
+    }
+
+    /**
+     * Fetch an activity feed for the given user.
+     *
+     * @param  User $user
+     * @param  int  $take
+     *
+     * @return \Illuminate\Database\Eloquent\Collection;
+     */
+    public static function paginatedFeed($user)
+    {
+        return static::where('user_id', $user->id)
+            ->latest()
+            ->with('subject');
     }
 }

--- a/app/Activity.php
+++ b/app/Activity.php
@@ -24,6 +24,7 @@ class Activity extends Model
                 $favoritedModel = Reply::find($subject->favorited_id);
             }
         }
+
         return $favoritedModel;
     }
 

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -26,4 +26,9 @@ class ProfilesController extends Controller
 
         return view('profiles.show', $data);
     }
+
+    public function index(User $user)
+    {
+        return ['activities' => Activity::paginatedFeed($user)->paginate(2)];
+    }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -146,4 +146,13 @@ class Reply extends Model
     {
         return $this->isBest();
     }
+
+    public function getXP()
+    {
+        $xp = $this->isBest() ? config('council.reputation.best_reply_awarded') : 0;
+        $xp += config('council.reputation.reply_posted');
+        $xp += $this->favorites()->count() * config('council.reputation.reply_favorited');
+
+        return $xp;
+    }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -19,12 +19,18 @@ Vue.component(
     require("./components/UserNotifications.vue")
 );
 Vue.component("avatar-form", require("./components/AvatarForm.vue"));
+Vue.component("activities", require("./components/Activities"));
+Vue.component("activity-layout", require("./components/ActivityLayout"));
+Vue.component("activity-favorite", require("./components/ActivityFavorite"));
+Vue.component("activity-reply", require("./components/ActivityReply"));
+Vue.component("activity-thread", require("./components/ActivityThread"));
 Vue.component("wysiwyg", require("./components/Wysiwyg.vue"));
 Vue.component("dropdown", require("./components/Dropdown.vue"));
 Vue.component("channel-dropdown", require("./components/ChannelDropdown.vue"));
 Vue.component("logout-button", require("./components/LogoutButton"));
 Vue.component("login", require("./components/Login"));
 Vue.component("register", require("./components/Register"));
+Vue.component("highlight", require("./components/Highlight"));
 
 Vue.component("thread-view", require("./pages/Thread.vue"));
 

--- a/resources/assets/js/components/Activities.vue
+++ b/resources/assets/js/components/Activities.vue
@@ -1,0 +1,59 @@
+<template>
+    <div>
+        <div ref="timeline" class="mt-2">&nbsp;</div>
+        <div class="relative w-full max-w-full border-l-4 border-grey">
+            <div v-for="(activity, index) in items" :key="activity.id">
+                <div class="entry">
+                    <activity-favorite :last="lastActivity(index)" :activity="activity" v-if="activity.type === 'created_favorite'"/>
+                    <activity-reply :last="lastActivity(index)" :activity="activity" v-if="activity.type === 'created_reply'"/>
+                    <activity-thread :last="lastActivity(index)" :activity="activity" v-if="activity.type === 'created_thread'"/>
+                </div>
+            </div>
+        </div>
+        <paginator class="list-reset py-2 mb-4" :data-set="dataSet" @changed="fetch"/>
+    </div>
+</template>
+
+<script>
+    export default {
+        name: "Activities",
+
+        props: {
+            user: {
+                type: Object,
+                required: true
+            }
+        },
+
+        data() {
+            return {
+                dataSet: false,
+                items: false
+            };
+        },
+
+        created() {
+            this.fetch();
+        },
+
+        methods: {
+            fetch(page) {
+                axios.get(this.url(page)).then(this.refresh);
+            },
+
+            url(page) {
+                let url = `/profiles/${this.user.username}/activity`;
+                return page ? `${url}?page=${page}` : `${url}?page=1`;
+            },
+
+            refresh({data}) {
+                this.dataSet = data.activities;
+                this.items = data.activities.data;
+                this.$refs.timeline.scrollIntoView();
+            },
+            lastActivity(index) {
+                return (index === this.items.length -1);
+            }
+        },
+    };
+</script>

--- a/resources/assets/js/components/ActivityFavorite.vue
+++ b/resources/assets/js/components/ActivityFavorite.vue
@@ -1,0 +1,33 @@
+<template>
+    <activity-layout :last="last">
+        <span slot="activity">
+            favorited a <a class="text-blue" :href="activity.favoritedModel.path"><strong>reply </strong></a>
+            {{ humanTime(activity.favoritedModel.created_at) }} in:
+        </span>
+
+        <div slot="heading" class="text-xl font-semibold my-4">
+            <a class="text-blue font-bold mb-4" :href="activity.favoritedModel.path">"{{ activity.favoritedModel.thread.title }}"</a>
+            <p class="text-2xs text-grey-darkest font-medium mb-4">
+                Posted By: <a :href="activity.favoritedModel.thread.creator.username" class="text-blue">{{
+                activity.favoritedModel.thread.creator.username }}</a>
+            </p>
+        </div>
+
+        <div slot="body">
+            <div class="text-grey-darkest leading-loose mb-4 max-h-24 overflow-hidden">
+                <div class="ml-6 my-4 pl-4 border-l-2 border-grey-dark">
+                    <highlight :content="activity.favoritedModel.body"/>
+                </div>
+            </div>
+            <div class="flex items-center py-1 text-xs text-grey-darkest">
+                &#8943; <a class="ml-1 text-2xs text-blue" :href="activity.favoritedModel.path">more</a>
+            </div>
+        </div>
+    </activity-layout>
+</template>
+<script>
+    import activity from "../mixins/activity";
+    export default {
+        mixins: [activity],
+    };
+</script>

--- a/resources/assets/js/components/ActivityLayout.vue
+++ b/resources/assets/js/components/ActivityLayout.vue
@@ -1,0 +1,30 @@
+<template>
+    <div class="flex items-center">
+        <div class="title"/>
+        <div class="mt-0 mr-0 w-full pl-6" :class="{'mb-10': !last }">
+            <div class="rounded border border-grey">
+                <div class="px-6 py-4">
+                    <div class="text-sm mb-1">
+                        <div class="text-grey-darkest flex content-center">
+                            <slot name="activity"></slot>
+                        </div>
+                    </div>
+                    <slot name="heading"></slot>
+                    <slot name="body"></slot>
+                </div>
+                <slot name="badges"></slot>
+            </div>
+        </div>
+    </div>
+</template>
+<script>
+    export default {
+        props: {
+            last: {
+                type: Boolean,
+                required: false,
+                default: false
+            }
+        }
+    };
+</script>

--- a/resources/assets/js/components/ActivityReply.vue
+++ b/resources/assets/js/components/ActivityReply.vue
@@ -1,0 +1,56 @@
+<template>
+    <activity-layout :last="last">
+        <span slot="activity">
+            added a&nbsp;<a class="mr-1 text-blue" :href="activity.subject.path"><strong>reply</strong></a>
+            {{ humanTime(activity.subject.created_at) }} in:
+        </span>
+
+        <div slot="heading" class="text-xl font-semibold my-4">
+            <a class="text-blue font-bold mb-4" :href="activity.subject.thread.path">"{{ activity.subject.thread.title }}"</a>
+            <p class="text-2xs text-grey-darkest font-medium mb-4">
+                Posted By: <a :href="activity.subject.thread.creator.username" class="text-blue">{{
+                activity.subject.thread.creator.username }}</a>
+            </p>
+        </div>
+
+        <div slot="body">
+            <div class="text-grey-darkest leading-loose mb-4 max-h-24 overflow-hidden">
+                <div class="ml-6 my-4 pl-4 border-l-2 border-grey-dark">
+                    <highlight :content="activity.subject.body"/>
+                </div>
+            </div>
+            <div class="flex items-center py-1 text-xs text-grey-darkest">
+                &#8943; <a class="ml-1 text-2xs text-blue" :href="activity.subject.path">more</a>
+            </div>
+        </div>
+
+        <div slot="badges" class="flex items-center mx-6 mb-6 text-sm">
+            <div class="text-2xs flex items-center mr-2 text-xs">
+                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="14" viewBox="0 0 20 19" class="fill-current">
+                    <g fill="none" fill-rule="evenodd">
+                        <path d="M-2-3h24v24H-2z"/>
+                        <path fill="#00DF8F" d="M14.5 0c-1.74 0-3.41.81-4.5 2.09C8.91.81 7.24 0 5.5 0 2.42 0 0 2.42 0 5.5c0 3.78 3.4 6.86 8.55 11.54L10 18.35l1.45-1.32C16.6 12.36 20 9.28 20 5.5 20 2.42 17.58 0 14.5 0z"/>
+                    </g>
+                </svg>
+                <span class="text-grey-darker text-2xs font-semibold  ml-1">{{ activity.subject.favoritesCount }} Favorite(s)</span>
+            </div>
+            <div v-if="activity.subject.isBest" class="text-grey-darker text-2xs font-semibold flex items-center mr-2">
+                <span class="mr-2 font-bold flex items-center">
+                    <span class="ml-2 mr-1">Best Answer!</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 20 20"
+                         class="fill-current text-green">
+                        <path fill-rule="evenodd" d="M9.99 0C4.47 0 0 4.48 0 10s4.47 10 9.99 10C15.52 20 20 15.52 20 10S15.52 0 9.99 0zm4.24 16L10 13.45 5.77 16l1.12-4.81-3.73-3.23 4.92-.42L10 3l1.92 4.53 4.92.42-3.73 3.23L14.23 16z"/>
+                    </svg>
+                </span>
+            </div>
+            <div class="flex items-center w-auto h-4 px-2 bg-green rounded font-semibold text-2xs text-white">XP +{{ activity.subject.xp }}</div>
+        </div>
+    </activity-layout>
+</template>
+
+<script>
+    import activity from "../mixins/activity";
+    export default {
+        mixins: [activity],
+    };
+</script>

--- a/resources/assets/js/components/ActivityThread.vue
+++ b/resources/assets/js/components/ActivityThread.vue
@@ -1,0 +1,48 @@
+<template>
+    <activity-layout>
+        <span slot="activity">
+            added a&nbsp;<a class="mr-1 text-blue" :href="activity.subject.path"><strong>thread</strong></a>
+            {{ humanTime(activity.subject.created_at) }} in:
+        </span>
+
+        <div slot="heading" class="text-xl font-semibold my-4">
+            <a class="text-blue font-bold mb-4" :href="activity.subject.path">"{{ activity.subject.title }}"</a>
+            <p class="text-2xs text-grey-darkest font-medium mb-4">
+                Posted By:
+                <a :href="activity.subject.creator.username" class="text-blue">
+                    {{ activity.subject.creator.username }}
+                </a>
+            </p>
+        </div>
+
+        <div slot="body">
+            <div class="text-grey-darkest leading-loose mb-4 max-h-24 overflow-hidden">
+                <div class="ml-6 my-4 pl-4 border-l-2 border-grey-dark">
+                    <highlight :content="activity.subject.body"/>
+                </div>
+            </div>
+            <div class="flex items-center py-1 text-xs text-grey-darkest">
+                &#8943; <a class="ml-1 text-2xs text-blue" :href="activity.subject.path">more</a>
+            </div>
+        </div>
+
+        <div slot="badges" class="flex items-center mx-6 mb-6 text-sm">
+            <div v-if="activity.subject.replies_count > 0"
+                 class="text-grey-darker text-2xs font-semibold flex items-center mr-4">
+                <svg xmlns="http://www.w3.org/2000/svg" width="19" height="14" viewBox="0 0 19 14" class="mr-1">
+                    <g fill="none" fill-rule="evenodd">
+                        <path d="M0-3h19v19H0z"/>
+                        <path fill="#C1C1CE" d="M10.292 6.5h5.541v1.187h-5.541V6.5zm0-1.98h5.541v1.188h-5.541V4.521zm0 3.96h5.541v1.187h-5.541V8.479zM16.625.166H2.375C1.505.167.792.879.792 1.75v10.292c0 .87.712 1.583 1.583 1.583h14.25c.87 0 1.583-.713 1.583-1.583V1.75c0-.87-.712-1.583-1.583-1.583zm0 11.875H9.5V1.75h7.125v10.292z"/>
+                    </g>
+                </svg>
+                {{ activity.subject.replies_count }} Reply(s)
+            </div>
+        </div>
+    </activity-layout>
+</template>
+<script>
+    import activity from "../mixins/activity";
+    export default {
+        mixins: [activity],
+    };
+</script>

--- a/resources/assets/js/components/Paginator.vue
+++ b/resources/assets/js/components/Paginator.vue
@@ -1,13 +1,13 @@
 <template>
-    <ul class="pagination" v-if="shouldPaginate">
-        <li v-show="prevUrl">
+    <ul v-if="shouldPaginate">
+        <li v-show="prevUrl" class="inline">
             <a href="#" aria-label="Previous" rel="prev" @click.prevent="page--">
-                <span aria-hidden="true">&laquo; Previous</span>
+                <span class="text-xs mr-2" aria-hidden="true">&laquo; Previous</span>
             </a>
         </li>
-        <li v-show="nextUrl">
+        <li v-show="nextUrl" class="inline">
             <a href="#" aria-label="Next" rel="next" @click.prevent="page++">
-                <span aria-hidden="true">Next &raquo;</span>
+                <span class="text-xs" aria-hidden="true">Next &raquo;</span>
             </a>
         </li>
     </ul>
@@ -15,7 +15,7 @@
 
 <script>
     export default {
-        props: ['dataSet'],
+        props: ["dataSet"],
 
         data() {
             return {
@@ -45,11 +45,11 @@
 
         methods: {
             broadcast() {
-                return this.$emit('changed', this.page);
+                return this.$emit("changed", this.page);
             },
 
             updateUrl() {
-                history.pushState(null, null, '?page=' + this.page);
+                history.pushState(null, null, "?page=" + this.page);
             }
         }
     }

--- a/resources/assets/js/mixins/activity.js
+++ b/resources/assets/js/mixins/activity.js
@@ -1,0 +1,20 @@
+import moment from "moment";
+
+export default {
+    props: {
+        activity: {
+            type: Object,
+            required: true
+        },
+        last: {
+            type: Boolean,
+            required: false,
+            default: false
+        }
+    },
+    methods: {
+        humanTime(timestamp) {
+            return moment(timestamp).fromNow();
+        }
+    }
+};

--- a/resources/views/profiles/show.blade.php
+++ b/resources/views/profiles/show.blade.php
@@ -1,25 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
-    <div class="container">
-        <div class="row">
-            <div class="col-md-8 col-md-offset-2">
-                <div class="page-header">
-                    <avatar-form :user="{{ $profileUser }}"></avatar-form>
-                </div>
-
-                @forelse ($activities as $date => $activity)
-                    <h3 class="page-header">{{ $date }}</h3>
-
-                    @foreach ($activity as $record)
-                        @if (view()->exists("profiles.activities.{$record->type}"))
-                            @include ("profiles.activities.{$record->type}", ['activity' => $record])
-                        @endif
-                    @endforeach
-                @empty
-                    <p>There is no activity for this user yet.</p>
-                @endforelse
-            </div>
-        </div>
+    <div class="mb-8">
+        <avatar-form :user="{{ $profileUser }}"></avatar-form>
     </div>
+
+    <activities :user="{{ $profileUser }}"></activities>
+
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ Route::post('/replies/{reply}/favorites', 'FavoritesController@store')->name('re
 Route::delete('/replies/{reply}/favorites', 'FavoritesController@destroy')->name('replies.unfavorite');
 
 Route::get('/profiles/{user}', 'ProfilesController@show')->name('profile');
+Route::get('/profiles/{user}/activity', 'ProfilesController@index')->name('activity');
 Route::get('/profiles/{user}/notifications', 'UserNotificationsController@index')->name('user-notifications');
 Route::delete('/profiles/{user}/notifications/{notification}', 'UserNotificationsController@destroy')->name('user-notification.destroy');
 


### PR DESCRIPTION
This PR is a response to @JeffreyWay who asked for a pull request that styled the user profile page in the Laracasts video https://laracasts.com/series/how-to-manage-an-open-source-project/episodes/20.

🚨 **Note** this is **work in progress**.
- there are a couple of tests to fix.
- there are a couple of tests to implement.

Having said that, I think its in a relatively good place. @JeffreyWay you are free to merge if you think its _good enough_ for you to work with.

⚠️ Note that in  `.resources/assets/sass/_timeline.scss` there are a small number of styles for the timeline that can't be implemented via tailwind yet. At least I couldn't work out how 🤷‍♂️ 

**Features**
- Style the user activity following existing Council design precedence.
- On all activities show the amount of XP gained.
- On reply created activity show the number of favorites gained and if the reply is marked as the best answer.
- On thread created activity show the number of replies submitted.
- Paginate the profile activity using Vue and existing pagination component.

**Future Work**
1. Style the avatar upload section, potentially using Vue to make the interaction better.

![screenshot-2018-2-19 council](https://user-images.githubusercontent.com/1974648/36426129-05cce61a-1641-11e8-899a-eb4ba80906c6.png)