### PR TITLE
Wrap the Modals in a div with the v-cloak to prevent the momentary "blink"

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -49,7 +49,9 @@
 
         <flash message="{{ session('flash') }}"></flash>
 
-        @include('modals.all')
+        <div v-cloak>
+            @include('modals.all')
+        </div>
     </div>
 
     <!-- Scripts -->


### PR DESCRIPTION
Because the modal component is loaded through JavaScript when the page loads the `modals.all` partial renders only the raw HTML until the JavaScript is loaded.

Wrapping the `@inclue()` method in a `div` with the `[v-cloak]` attribute uses CSS to hide this from view until the JavaScript has finished loading as described here https://vuejs.org/v2/api/#v-cloak.