### PR TITLE
Enable foreign key constraints dynamically

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,7 @@
 namespace Tests;
 
 use App\Exceptions\Handler;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
@@ -15,7 +15,7 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        DB::statement('PRAGMA foreign_keys=on;');
+        Schema::enableForeignKeyConstraints();
 
         $this->disableExceptionHandling();
     }


### PR DESCRIPTION
This PR allows us to enable foreign key constraints dynamically. When running the command:

    DB::statement('PRAGMA foreign_keys=on;');

it will enable foreign key constraints only on sqlite. The intended change will make it dynamic, and will not be specific to sqlite etc.

    Schema::enableForeignKeyConstraints();