### PR TITLE
Add v-cloak to prevent the form from showing on page load.

### DIFF
--- a/resources/views/threads/_question.blade.php
+++ b/resources/views/threads/_question.blade.php
@@ -1,5 +1,5 @@
 {{-- Editing the question. --}}
-<modal name="update-thread" height="auto">
+<modal name="update-thread" height="auto" v-cloak>
     <div class="p-6 py-8">
         <div class="mb-6 -mx-4">
             <div class="px-4 mb-6">


### PR DESCRIPTION
The form for editing a thread shows for a split second when loading the page (Even when visiting as a guest).

The `v-cloak` is a quick fix for this.