### PR TITLE
Add back missing blue dots to profile activity.

### DIFF
--- a/resources/assets/js/components/Activities.vue
+++ b/resources/assets/js/components/Activities.vue
@@ -2,7 +2,7 @@
     <div>
         <div ref="timeline" class="mt-2">&nbsp;</div>
 
-        <div class="relative w-full max-w-full border-l-4 border-grey-light">
+        <div class="timeline relative w-full max-w-full border-l-4 border-grey-light">
             <div v-for="(activity, index) in items" :key="activity.id">
                 <div class="entry">
                     <activity-favorite :activity="activity" v-if="activity.type === 'created_favorite'"/>

--- a/resources/assets/js/components/ActivityLayout.vue
+++ b/resources/assets/js/components/ActivityLayout.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="flex items-center">
+        <div class="title">&nbsp;</div>
         <div class="mt-0 mr-0 mb-10 w-full pl-6">
             <div class="rounded border border-grey-light">
                 <div class="px-6 py-4">

--- a/resources/assets/sass/_timeline.scss
+++ b/resources/assets/sass/_timeline.scss
@@ -1,0 +1,17 @@
+.timeline {
+  .entry {
+    clear: both;
+    text-align: left;
+    position: relative;
+    .title {
+      @apply absolute float-left text-right;
+      &:before {
+        content: '';
+        @apply absolute h-6 w-6 rounded-full bg-blue-darker border-4 border-blue-darker;
+        top: -1.5rem;
+        right: calc(-.25rem - 2px);
+        z-index: 99;
+      }
+    }
+  }
+}

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -6,6 +6,8 @@
 @import "sections/search";
 @import "sections/trix";
 
+@import "timeline";
+
 @tailwind utilities;
 
 a {


### PR DESCRIPTION
@JeffreyWay First off, sorry for the state of the profile styling PR. Yes, it was work in progress but I had completely screwed up the branch in an attempt to rebase it. I had thought it was fixed but clearly not. 

As you mentioned in the Laracasts episode, you were confused about the missing `_timeline.scss` file. This PR fixes that. 

- add missing `_timeline.scss` file.
- add back required markup to Vue components.

**Note** I wasn't sure whether to put the styles in `app.scss`,  or in `components/timeline.scss. Not a big issue but I thought you may want to try and figure out if its possible to implement in a nicer way so I just left it.

![screenshot-2018-3-2 council](https://user-images.githubusercontent.com/1974648/36924459-8e1025f0-1e66-11e8-9152-7238a68a89bf.png)
