### PR TITLE
Adjust DB seeder channels call

### DIFF
--- a/database/seeds/SampleDataSeeder.php
+++ b/database/seeds/SampleDataSeeder.php
@@ -36,38 +36,32 @@ class SampleDataSeeder extends Seeder
             [
                 'name' => 'PHP',
                 'description' => 'A channel for general PHP questions. Use this channel if you can\'t find a more specific channel for your question.',
-                'archived' => false,
                 'color' => '#008000'
             ],
             [
                 'name' => 'Vue',
                 'description' => 'A channel for general Vue questions. Use this channel if you can\'t find a more specific channel for your question.',
-                'archived' => false,
                 'color' => '#cccccc'
             ],
             [
                 'name' => 'Laravel Mix',
                 'description' => 'This channel is for all Laravel Mix related questions.',
-                'archived' => false,
                 'color' => '#43DDF5'
             ],
             [
                 'name' => 'Eloquent',
                 'description' => 'This channel is for all Laravel Eloquent related questions.',
-                'archived' => false,
                 'color' => '#a01212'
             ],
             [
                 'name' => 'Vuex',
                 'description' => 'This channel is for all Vuex related questions.',
-                'archived' => false,
                 'color' => '#ff8822'
             ],
         ])->each(function ($channel) {
             factory(Channel::class)->create([
                 'name' => $channel['name'],
                 'description' => $channel['description'],
-                'archived' => false,
                 'color' => $channel['color']
             ]);
         });

--- a/database/seeds/SampleDataSeeder.php
+++ b/database/seeds/SampleDataSeeder.php
@@ -40,8 +40,8 @@ class SampleDataSeeder extends Seeder
                 'color' => '#008000'
             ],
             [
-                'name' => 'VueJS',
-                'description' => 'A channel for general VueJS questions. Use this channel if you can\'t find a more specific channel for your question.',
+                'name' => 'Vue',
+                'description' => 'A channel for general Vue questions. Use this channel if you can\'t find a more specific channel for your question.',
                 'archived' => false,
                 'color' => '#cccccc'
             ],
@@ -58,8 +58,8 @@ class SampleDataSeeder extends Seeder
                 'color' => '#a01212'
             ],
             [
-                'name' => 'VueEx',
-                'description' => 'This channel is for all VueEx specific questions.',
+                'name' => 'Vuex',
+                'description' => 'This channel is for all Vuex related questions.',
                 'archived' => false,
                 'color' => '#ff8822'
             ],


### PR DESCRIPTION
Nothing really special here; just updating some wording and code references.

I've found a very strange bug though. If you remove the `'archived' => false` reference from the model factory and then run the test suite again, 2 errors will come up saying "Failed asserting that null is false.", `null` referring to the `archived` property on a Channel instance, even though it's set to `false` by default in the migration file.

Using `dd()` to debug shows that it's not in the attributes list at all when running tests, but works perfectly fine in development (MySQL). I'm guessing this might have something to do with SQLite? Or maybe I'm just missing something.