### PR TITLE
Initial Leaderboard Implementation

### DIFF
--- a/app/Http/Controllers/Api/LeaderboardController.php
+++ b/app/Http/Controllers/Api/LeaderboardController.php
@@ -9,6 +9,8 @@ class LeaderboardController extends Controller
 {
     public function index()
     {
-        return User::limit(10)->orderBy('reputation', 'desc')->get();
+        return [
+            'leaderboard' => User::limit(10)->orderBy('reputation', 'desc')->get()
+        ];
     }
 }

--- a/app/Http/Controllers/Api/LeaderboardController.php
+++ b/app/Http/Controllers/Api/LeaderboardController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\User;
+use App\Http\Controllers\Controller;
+
+class LeaderboardController extends Controller
+{
+    public function index()
+    {
+        return User::limit(10)->orderBy('reputation', 'desc')->get();
+    }
+}

--- a/app/Http/Controllers/LeaderboardController.php
+++ b/app/Http/Controllers/LeaderboardController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class LeaderboardController extends Controller
+{
+    public function index()
+    {
+        return view('leaderboard.index');
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -48,7 +48,8 @@ class User extends Authenticatable
      * @var array
      */
     protected $casts = [
-        'confirmed' => 'boolean'
+        'confirmed' => 'boolean',
+        'reputation' => 'integer'
     ];
 
     /**

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -31,6 +31,7 @@ Vue.component("logout-button", require("./components/LogoutButton"));
 Vue.component("login", require("./components/Login"));
 Vue.component("register", require("./components/Register"));
 Vue.component("highlight", require("./components/Highlight"));
+Vue.component("leaderboard", require("./components/Leaderboard"));
 
 Vue.component("thread-view", require("./pages/Thread.vue"));
 

--- a/resources/assets/js/components/Leaderboard.vue
+++ b/resources/assets/js/components/Leaderboard.vue
@@ -1,0 +1,50 @@
+<template>
+    <div>
+        <div v-for="(user, key) in leaderboard" :key="user.id" class="my-10 p-4 rounded border border-grey-light flex justify-between">
+            <div class="flex">
+                <img :src="user.avatar_path" :alt="user.username" :class="avatarClasses(user.avatar_path)" class="w-16 h-16 rounded-full mr-3">
+                <div class="flex flex-col text-grey">
+                    <a :href="userProfileLink(user.username)" class="mb-4 text-xl text-blue">{{ user.username }}</a>
+                    <span class="text-grey-darkest font-bold">{{ user.reputation }} <span class="text-grey">reputation</span> </span>
+                </div>
+            </div>
+            <span class="text-5xl text-grey-light">{{ key+1 }}</span>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'Leaderboard',
+
+    data() {
+        return {
+            leaderboard: {}
+        };
+    },
+
+    created() {
+        this.fetch();
+    },
+
+    methods: {
+        fetch() {
+            window.axios.get('api/leaderboard').then(this.refresh);
+        },
+
+        refresh({ data }) {
+            this.leaderboard = data.leaderboard;
+        },
+
+        userProfileLink(username) {
+            return `/profiles/${username}`;
+        },
+
+        avatarClasses(avatarPath) {
+            return {
+                'bg-blue-darker p-2': avatarPath.endsWith('default.svg')
+            }
+        }
+    }
+};
+</script>

--- a/resources/assets/js/components/Leaderboard.vue
+++ b/resources/assets/js/components/Leaderboard.vue
@@ -3,9 +3,9 @@
         <div v-for="(user, key) in leaderboard" :key="user.id" class="my-10 p-4 rounded border border-grey-light flex justify-between">
             <div class="flex">
                 <img :src="user.avatar_path" :alt="user.username" :class="avatarClasses(user.avatar_path)" class="w-16 h-16 rounded-full mr-3">
-                <div class="flex flex-col text-grey">
-                    <a :href="userProfileLink(user.username)" class="mb-4 text-xl text-blue">{{ user.username }}</a>
-                    <span class="text-grey-darkest font-bold">{{ user.reputation }} <span class="text-grey">reputation</span> </span>
+                <div>
+                    <a :href="userProfileLink(user.username)" class="inline mb-4 text-xl text-blue">{{ user.username }}</a>
+                    <span class="inline px-2 bg-green rounded font-semibold text-white">{{ user.reputation }} XP</span>
                 </div>
             </div>
             <span class="text-5xl text-grey-light">{{ key+1 }}</span>

--- a/resources/views/leaderboard/index.blade.php
+++ b/resources/views/leaderboard/index.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="my-10"><h1>Leaderboard</h1></div>
+    <leaderboard></leaderboard>
+@endsection

--- a/resources/views/sidebar.blade.php
+++ b/resources/views/sidebar.blade.php
@@ -16,7 +16,7 @@
     <div class="widget">
         <h4 class="widget-heading">Browse</h4>
 
-        <ul class="list-reset text-sm">
+        <ul class="mb-2 list-reset text-sm">
             <li class="pb-3">
                 <a href="/threads" class="flex items-center text-grey-darkest hover:text-blue hover:font-bold {{ Request::is('threads') && ! Request::query() ? 'text-blue font-bold' : '' }}">
                     @include ('svgs.icons.all-threads', ['class' => 'mr-3 text-grey'])
@@ -45,13 +45,22 @@
                 </a>
             </li>
 
-            <li>
+            <li class="pb-3">
                 <a href="/threads?unanswered=1" class="flex items-center text-grey-darkest hover:text-blue hover:font-bold {{ Request::query('unanswered') ? 'text-blue font-bold' : '' }}">
                     @include ('svgs.icons.question', ['class' => 'mr-3 text-grey'])
                     Unanswered Threads
                 </a>
             </li>
+
+            <li>
+                <a href="/leaderboard" class="flex items-center text-grey-darkest hover:text-blue hover:font-bold {{ request()->getPathInfo() === '/leaderboard' ? 'text-blue font-bold' : '' }}">
+                    @include ('svgs.icons.leaderboard')
+                    Leaderboard
+                </a>
+            </li>
+
         </ul>
+
     </div>
 
     @if (count($trending))

--- a/resources/views/svgs/icons/leaderboard.blade.php
+++ b/resources/views/svgs/icons/leaderboard.blade.php
@@ -1,0 +1,3 @@
+<span class="mr-3 w-4 h-4 text-grey-dark font-bold border-t-2 border-grey">
+	<div class="self-center">LB</div>
+</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,7 +54,10 @@ Route::get('/register/confirm', 'Auth\RegisterConfirmationController@index')->na
 Route::get('api/users', 'Api\UsersController@index')->name('api.users');
 Route::post('api/users/{user}/avatar', 'Api\UserAvatarController@store')->middleware('auth')->name('avatar');
 Route::get('api/channels', 'Api\ChannelsController@index');
+
+
 Route::get('api/leaderboard', 'Api\LeaderboardController@index')->name('api.leaderboard.index');
+Route::get('leaderboard', 'LeaderboardController@index')->name('leaderboard.index');
 
 Route::group([
     'prefix' => 'admin',

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,6 @@ Route::get('api/users', 'Api\UsersController@index')->name('api.users');
 Route::post('api/users/{user}/avatar', 'Api\UserAvatarController@store')->middleware('auth')->name('avatar');
 Route::get('api/channels', 'Api\ChannelsController@index');
 
-
 Route::get('api/leaderboard', 'Api\LeaderboardController@index')->name('api.leaderboard.index');
 Route::get('leaderboard', 'LeaderboardController@index')->name('leaderboard.index');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,7 @@ Route::get('/register/confirm', 'Auth\RegisterConfirmationController@index')->na
 Route::get('api/users', 'Api\UsersController@index')->name('api.users');
 Route::post('api/users/{user}/avatar', 'Api\UserAvatarController@store')->middleware('auth')->name('avatar');
 Route::get('api/channels', 'Api\ChannelsController@index');
+Route::get('api/leaderboard', 'Api\LeaderboardController@index')->name('api.leaderboard.index');
 
 Route::group([
     'prefix' => 'admin',

--- a/tests/Feature/LeaderboardTest.php
+++ b/tests/Feature/LeaderboardTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LeaderboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_lists_the_top_10_users_sorted_by_reputation()
+    {
+        collect([1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100])->each(function ($reputation) {
+            create(User::class, [
+                'reputation' => $reputation
+            ]);
+        });
+
+        $reputation = collect($this->getJson(route('api.leaderboard.index'))->json())
+            ->pluck('reputation')
+            ->toArray();
+
+        $this->assertEquals([100, 90, 80, 70, 60, 50, 40, 30, 20, 10], $reputation);
+
+    }
+}

--- a/tests/Feature/LeaderboardTest.php
+++ b/tests/Feature/LeaderboardTest.php
@@ -3,15 +3,16 @@
 namespace Tests\Feature;
 
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class LeaderboardTest extends TestCase
 {
     use RefreshDatabase;
 
     /** @test */
-    public function it_lists_the_top_10_users_sorted_by_reputation()
+    public function it_retrieves_the_top_10_users_sorted_by_reputation()
     {
         collect([1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100])->each(function ($reputation) {
             create(User::class, [
@@ -19,11 +20,19 @@ class LeaderboardTest extends TestCase
             ]);
         });
 
-        $reputation = collect($this->getJson(route('api.leaderboard.index'))->json())
+        $reputation = collect($this->getJson(route('api.leaderboard.index'))->json()['leaderboard'])
             ->pluck('reputation')
             ->toArray();
 
         $this->assertEquals([100, 90, 80, 70, 60, 50, 40, 30, 20, 10], $reputation);
+    }
 
+    /** @test */
+    public function users_can_access_the_forum_leaderboard_page()
+    {
+        $this->get(route('leaderboard.index'))
+            ->assertStatus(Response::HTTP_OK)
+            ->assertViewIs('leaderboard.index')
+            ->assertSee('Leaderboard');
     }
 }


### PR DESCRIPTION
This PR introduces a rudimentary user 'leaderboard' that lists the top 10 users in descending order of reputation. 

- A 'Leaderboard' link is added to the main left nav.
- A simple leaderboard api endpoint is introduced.
- A new `Leaderboard.vue` component responsible for calling the leaderboard api and rendering the results is introduced.

**Note:** The file `resources/views/svgs/icons/leaderboard.blade.php` is not an SVG file. It is simple html with tailwind styling but an SVG can be added at a later date.

### Future considerations

- Add more metadata to the entries on the leaderboard page, for example, number of threads, number of replies and number of best replies. 

I considered adding these but quickly realised that it was a fairly big job. It would require adding accessors on models (to calculate the data) that arguably shouldn't be there. I thought about adding a new 'UserData' table and model that would be populated via events and listeners but again a lot of changes would be required. 

In the end I settled for the simplest option which gets us started. 

![screenshot-2018-3-5 council](https://user-images.githubusercontent.com/1974648/36985776-0bfcacd8-2090-11e8-83c7-f58ceb71ad78.png)
