### PR TITLE
UX fix - Delay hover activation in navigation

### DIFF
--- a/resources/assets/js/components/Dropdown.vue
+++ b/resources/assets/js/components/Dropdown.vue
@@ -1,6 +1,6 @@
 <template>
-    <div @mouseover="active = true"
-         @mouseout="active = false"
+    <div @mouseover="activate"
+         @mouseout="deactivate"
          class="relative cursor-pointer relative z-10"
     >
         <slot name="heading"></slot>
@@ -19,11 +19,10 @@
 </template>
 
 <script>
+
+    import activation from '../mixins/activation';
+
     export default {
-        data() {
-            return {
-                active: false
-            };
-        }
+        mixins: [ activation ],
     }
 </script>

--- a/resources/assets/js/components/UserNotifications.vue
+++ b/resources/assets/js/components/UserNotifications.vue
@@ -1,5 +1,5 @@
 <template>
-    <div @mouseover="active = true" @mouseout="active = false">
+    <div @mouseover="activate" @mouseout="deactivate">
        <div class="rounded-full bg-blue-darkest w-10 h-10 flex items-center justify-center mr-4 cursor-pointer relative z-10">
             <!-- "New Notifications Available" bubble. -->
             <div class="rounded-full bg-red w-2 h-2 absolute pin-t pin-r mt-1" v-if="notifications.length"></div>
@@ -47,9 +47,15 @@
 </template>
 
 <script>
+
+    import activation from '../mixins/activation';
+
     export default {
+
+        mixins: [ activation ],
+
         data() {
-            return { notifications: false, active: false }
+            return { notifications: false }
         },
 
         created() {

--- a/resources/assets/js/mixins/activation.js
+++ b/resources/assets/js/mixins/activation.js
@@ -1,0 +1,32 @@
+export default {
+
+        data() {
+            return {
+                active: false,
+                timer: null, 
+            };
+        },
+
+        methods: {
+            activate() {
+
+                window.clearTimeout( this.timer );
+
+                this.timer = window.setTimeout( () => {
+                    this.active = true;
+                }, 100 );
+
+            },
+
+            deactivate() {
+
+                window.clearTimeout( this.timer );
+
+                this.timer = window.setTimeout( () => {
+                    this.active = false;
+                }, 100 );
+
+            }
+        }
+
+}


### PR DESCRIPTION
## The case

If you accidentally hover over the wrong button in the navigation, it will overlap the button you want to interact with.

![council-quick-pupup](https://user-images.githubusercontent.com/3670799/37021034-4e7f49ce-211e-11e8-9510-7380b91f2f54.gif)

## The fix

Adding a `100ms` delay before activating or deactivating the component it will be more forgiving to the user.

![council-hover-delay](https://user-images.githubusercontent.com/3670799/37021045-5ae86204-211e-11e8-817e-a87f57541adb.gif)
