### PR TITLE
Fix layout height when content does not fill full height.

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ config('app.locale') }}">
+<html lang="{{ config('app.locale') }}" class="h-full">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -29,12 +29,12 @@
     @yield('head')
 </head>
 
-<body class="font-sans bg-grey-lighter">
-    <div id="app">
+<body class="font-sans bg-grey-lighter h-full">
+    <div id="app" class="flex flex-col h-full">
         @include ('layouts.nav')
 
-        <div class="container mx-auto">
-            <div class="flex">
+        <div class="container mx-auto flex flex-1">
+            <div class="flex flex-1">
                 @section('sidebar')
                     @include('sidebar')
                 @show


### PR DESCRIPTION
When content does not fill the whole page the container is not using the full height.

As-Is situation on the admin page
![screen shot 2018-03-08 at 11 02 19](https://user-images.githubusercontent.com/5066883/37171255-894a4c8e-230d-11e8-862b-af991c3fb8b1.png)

This PR will result in
![screen shot 2018-03-08 at 20 14 31](https://user-images.githubusercontent.com/5066883/37171272-98d9087a-230d-11e8-99f4-a1c0efe40966.png)

Feedback is welcome if more efficient solutions exist.