### PR TITLE
Replace HTTP response codes with named constants

### DIFF
--- a/app/Http/Controllers/Admin/ChannelsController.php
+++ b/app/Http/Controllers/Admin/ChannelsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Channel;
+use Illuminate\Http\Response;
 use Illuminate\Validation\Rule;
 use App\Http\Controllers\Controller;
 
@@ -59,7 +60,7 @@ class ChannelsController extends Controller
         cache()->forget('channels');
 
         if (request()->wantsJson()) {
-            return response($channel, 200);
+            return response($channel, Response::HTTP_OK);
         }
 
         return redirect(route('admin.channels.index'))
@@ -84,7 +85,7 @@ class ChannelsController extends Controller
         cache()->forget('channels');
 
         if (request()->wantsJson()) {
-            return response($channel, 201);
+            return response($channel, Response::HTTP_CREATED);
         }
 
         return redirect(route('admin.channels.index'))

--- a/app/Http/Controllers/Api/UserAvatarController.php
+++ b/app/Http/Controllers/Api/UserAvatarController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use Illuminate\Http\Response;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Storage;
 
@@ -24,6 +25,6 @@ class UserAvatarController extends Controller
             'avatar_path' => request()->file('avatar')->store('avatars', 'public')
         ]);
 
-        return response([], 204);
+        return response([], Response::HTTP_NO_CONTENT);
     }
 }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
@@ -48,7 +49,7 @@ class LoginController extends Controller
     protected function authenticated(Request $request, $user)
     {
         if ($request->wantsJson()) {
-            return response()->json(['redirect' => $this->redirectTo], 200);
+            return response()->json(['redirect' => $this->redirectTo], Response::HTTP_OK);
         }
 
         redirect()->intended($this->redirectPath());

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Reply;
 use App\Thread;
+use Illuminate\Http\Response;
 use App\Http\Requests\CreatePostRequest;
 
 class RepliesController extends Controller
@@ -38,7 +39,7 @@ class RepliesController extends Controller
     public function store($channelId, Thread $thread, CreatePostRequest $form)
     {
         if ($thread->locked) {
-            return response('Thread is locked', 422);
+            return response('Thread is locked', Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
         return $thread->addReply([

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -6,6 +6,7 @@ use App\Thread;
 use App\Channel;
 use App\Trending;
 use App\Rules\Recaptcha;
+use Illuminate\Http\Response;
 use App\Filters\ThreadFilters;
 use Illuminate\Validation\Rule;
 
@@ -81,7 +82,7 @@ class ThreadsController extends Controller
         ]);
 
         if (request()->wantsJson()) {
-            return response($thread, 201);
+            return response($thread, Response::HTTP_CREATED);
         }
 
         return redirect($thread->path())
@@ -141,7 +142,7 @@ class ThreadsController extends Controller
         $thread->delete();
 
         if (request()->wantsJson()) {
-            return response([], 204);
+            return response([], Response::HTTP_NO_CONTENT);
         }
 
         return redirect('/threads');

--- a/app/Http/Middleware/Administrator.php
+++ b/app/Http/Middleware/Administrator.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Response;
 
 class Administrator
 {
@@ -19,6 +20,6 @@ class Administrator
             return $next($request);
         }
 
-        abort(403, 'You do not have permission to perform this action.');
+        abort(Response::HTTP_FORBIDDEN, 'You do not have permission to perform this action.');
     }
 }

--- a/tests/Feature/AddAvatarTest.php
+++ b/tests/Feature/AddAvatarTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -17,7 +18,7 @@ class AddAvatarTest extends TestCase
         $this->withExceptionHandling();
 
         $this->json('POST', 'api/users/1/avatar')
-            ->assertStatus(401);
+            ->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
     /** @test */
@@ -27,7 +28,7 @@ class AddAvatarTest extends TestCase
 
         $this->json('POST', route('avatar', auth()->id()), [
             'avatar' => 'not-an-image'
-        ])->assertStatus(422);
+        ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
     /** @test */

--- a/tests/Feature/Admin/AdministratorTest.php
+++ b/tests/Feature/Admin/AdministratorTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Admin;
 
 use Tests\TestCase;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class AdministratorTest extends TestCase

--- a/tests/Feature/Admin/ChannelAdministrationTest.php
+++ b/tests/Feature/Admin/ChannelAdministrationTest.php
@@ -5,7 +5,7 @@ namespace Tests\Feature\Admin;
 use App\User;
 use App\Channel;
 use Tests\TestCase;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ChannelAdministrationTest extends TestCase

--- a/tests/Feature/BestReplyTest.php
+++ b/tests/Feature/BestReplyTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class BestReplyTest extends TestCase
@@ -38,7 +39,7 @@ class BestReplyTest extends TestCase
 
         $this->signIn(create(\App\User::class));
 
-        $this->postJson(route('best-replies.store', [$replies[1]->id]))->assertStatus(403);
+        $this->postJson(route('best-replies.store', [$replies[1]->id]))->assertStatus(Response::HTTP_FORBIDDEN);
 
         $this->assertFalse($replies[1]->fresh()->isBest());
     }

--- a/tests/Feature/CreateThreadsTest.php
+++ b/tests/Feature/CreateThreadsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Activity;
 use Tests\TestCase;
+use Illuminate\Http\Response;
 use App\Rules\Recaptcha;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -28,7 +29,7 @@ class CreateThreadsTest extends TestCase
     {
         $this->withExceptionHandling();
 
-        $this->post(route('threads'))->assertStatus(302)->assertRedirect(route('login'));
+        $this->post(route('threads'))->assertStatus(Response::HTTP_FOUND)->assertRedirect(route('login'));
     }
 
     /** @test */
@@ -130,7 +131,7 @@ class CreateThreadsTest extends TestCase
         $this->delete($thread->path())->assertRedirect('/login');
 
         $this->signIn();
-        $this->delete($thread->path())->assertStatus(403);
+        $this->delete($thread->path())->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     /** @test */
@@ -143,7 +144,7 @@ class CreateThreadsTest extends TestCase
 
         $response = $this->json('DELETE', $thread->path());
 
-        $response->assertStatus(204);
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
 
         $this->assertDatabaseMissing('threads', ['id' => $thread->id]);
         $this->assertDatabaseMissing('replies', ['id' => $reply->id]);

--- a/tests/Feature/LeaderboardTest.php
+++ b/tests/Feature/LeaderboardTest.php
@@ -4,7 +4,7 @@ namespace Tests\Feature;
 
 use App\User;
 use Tests\TestCase;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class LeaderboardTest extends TestCase

--- a/tests/Feature/LockThreadsTest.php
+++ b/tests/Feature/LockThreadsTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class LockThreadsTest extends TestCase
@@ -19,7 +19,7 @@ class LockThreadsTest extends TestCase
 
         $thread = create(\App\Thread::class, ['user_id' => auth()->id()]);
 
-        $this->post(route('locked-threads.store', $thread))->assertStatus(403);
+        $this->post(route('locked-threads.store', $thread))->assertStatus(Response::HTTP_FORBIDDEN);
 
         $this->assertFalse($thread->fresh()->locked);
     }

--- a/tests/Feature/ParticipateInThreadsTest.php
+++ b/tests/Feature/ParticipateInThreadsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ParticipateInThreadsTest extends TestCase
@@ -55,7 +56,7 @@ class ParticipateInThreadsTest extends TestCase
 
         $this->signIn()
             ->delete("/replies/{$reply->id}")
-            ->assertStatus(403);
+            ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     /** @test */
@@ -64,7 +65,7 @@ class ParticipateInThreadsTest extends TestCase
         $this->signIn();
         $reply = create(\App\Reply::class, ['user_id' => auth()->id()]);
 
-        $this->delete("/replies/{$reply->id}")->assertStatus(302);
+        $this->delete("/replies/{$reply->id}")->assertStatus(Response::HTTP_FOUND);
 
         $this->assertDatabaseMissing('replies', ['id' => $reply->id]);
 
@@ -83,7 +84,7 @@ class ParticipateInThreadsTest extends TestCase
 
         $this->signIn()
             ->patch(route('replies.update', $reply->id))
-            ->assertStatus(403);
+            ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     /** @test */
@@ -112,7 +113,7 @@ class ParticipateInThreadsTest extends TestCase
         ]);
 
         $this->json('post', $thread->path() . '/replies', $reply->toArray())
-            ->assertStatus(422);
+            ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
     /** @test */
@@ -126,9 +127,9 @@ class ParticipateInThreadsTest extends TestCase
         $reply = make(\App\Reply::class);
 
         $this->post($thread->path() . '/replies', $reply->toArray())
-            ->assertStatus(201);
+            ->assertStatus(Response::HTTP_CREATED);
 
         $this->post($thread->path() . '/replies', $reply->toArray())
-            ->assertStatus(429);
+            ->assertStatus(Response::HTTP_TOO_MANY_REQUESTS);
     }
 }

--- a/tests/Feature/PinThreadsTest.php
+++ b/tests/Feature/PinThreadsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Thread;
 use Tests\TestCase;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class PinThreadsTest extends TestCase
@@ -19,7 +20,7 @@ class PinThreadsTest extends TestCase
 
         $thread = create(\App\Thread::class, ['user_id' => auth()->id()]);
 
-        $this->post(route('pinned-threads.store', $thread))->assertStatus(403);
+        $this->post(route('pinned-threads.store', $thread))->assertStatus(Response::HTTP_FORBIDDEN);
 
         $this->assertFalse($thread->fresh()->pinned, 'Failed asserting that the thread was unpinned.');
     }
@@ -33,7 +34,7 @@ class PinThreadsTest extends TestCase
 
         $thread = create(\App\Thread::class, ['user_id' => auth()->id(), 'pinned' => true]);
 
-        $this->delete(route('pinned-threads.destroy', $thread))->assertStatus(403);
+        $this->delete(route('pinned-threads.destroy', $thread))->assertStatus(Response::HTTP_FORBIDDEN);
 
         $this->assertTrue($thread->fresh()->pinned);
     }

--- a/tests/Feature/UpdateThreadsTest.php
+++ b/tests/Feature/UpdateThreadsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UpdateThreadsTest extends TestCase
@@ -23,7 +24,7 @@ class UpdateThreadsTest extends TestCase
     {
         $thread = create(\App\Thread::class, ['user_id' => create(\App\User::class)->id]);
 
-        $this->patch($thread->path(), [])->assertStatus(403);
+        $this->patch($thread->path(), [])->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
     /** @test */


### PR DESCRIPTION
The named constants are named after the HTTP response reason phrases. 
This way, a programmer does not always have to look-up the reason phrase
for unfamiliar codes.