### PR TITLE
Migration error solution

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,7 +12,7 @@ class AppServiceProvider extends ServiceProvider
      * @return void
      */
     public function boot()
-    {
+    {   \Schema::defaultStringLength(191);
         \Validator::extend('spamfree', 'App\Rules\SpamFree@passes');
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,7 +12,8 @@ class AppServiceProvider extends ServiceProvider
      * @return void
      */
     public function boot()
-    {   \Schema::defaultStringLength(191);
+    {   
+        \Schema::defaultStringLength(191);
         \Validator::extend('spamfree', 'App\Rules\SpamFree@passes');
     }
 


### PR DESCRIPTION
Illuminate\Database\QueryException  : SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was t
oo long; max key length is 767 bytes (SQL: alter table `users` add unique `users_username_unique`(`username`))