### PR TITLE
Remove reference to App\Mentions

### DIFF
--- a/tests/Feature/MentionUsersTest.php
+++ b/tests/Feature/MentionUsersTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Thread;
-use App\Mentions;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
Removes the import of App\Mentions which doesn't exist in the codebase.