### PR TITLE
Remove reference to App\Reputation

### DIFF
--- a/tests/Feature/ReputationTest.php
+++ b/tests/Feature/ReputationTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Reply;
 use App\Thread;
-use App\Reputation;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 


### PR DESCRIPTION
Removes the import of App\Reputation which isn't found in the codebase.